### PR TITLE
ci: Add HACS validation GitHub Action

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,0 +1,20 @@
+name: HACS Validation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    name: Validate
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: plugin


### PR DESCRIPTION
Add GitHub Action workflow for automated HACS validation:
- Runs on push, pull requests, and workflow dispatch
- Daily scheduled validation
- Uses hacs/action with plugin category
- Validates repository against HACS requirements