### PR TITLE
Fix vertical alignment of delay indicators in compact view

### DIFF
--- a/dist/my-rail-commute-card.js
+++ b/dist/my-rail-commute-card.js
@@ -233,6 +233,18 @@ const b=globalThis,x=t=>t,C=b.trustedTypes,A=C?C.createPolicy("lit-html",{create
     gap: 4px;
   }
 
+  .train-row-compact .status .status-icon {
+    display: flex;
+    align-items: center;
+    line-height: 1;
+  }
+
+  .train-row-compact .status .delay-text {
+    display: flex;
+    align-items: center;
+    line-height: 1;
+  }
+
   .train-row-compact.on-time .status {
     color: var(--status-on-time);
   }
@@ -1076,8 +1088,8 @@ const b=globalThis,x=t=>t,C=b.trustedTypes,A=C?C.createPolicy("lit-html",{create
               <span class="time">${lt(t.scheduled_departure)}</span>
               <span class="platform">Plat ${t.platform||"—"}</span>
               <span class="status">
-                ${!1!==this.config.status_icons?dt(t):""}
-                ${t.delay_minutes>0?` +${t.delay_minutes}m`:""}
+                ${!1!==this.config.status_icons?B`<span class="status-icon">${dt(t)}</span>`:""}
+                ${t.delay_minutes>0?B`<span class="delay-text">+${t.delay_minutes}m</span>`:""}
               </span>
             </div>
           `)}

--- a/src/my-rail-commute-card.js
+++ b/src/my-rail-commute-card.js
@@ -463,8 +463,8 @@ class MyRailCommuteCard extends LitElement {
               <span class="time">${formatTime(train.scheduled_departure)}</span>
               <span class="platform">Plat ${train.platform || '—'}</span>
               <span class="status">
-                ${this.config.status_icons !== false ? getStatusIcon(train) : ''}
-                ${train.delay_minutes > 0 ? ` +${train.delay_minutes}m` : ''}
+                ${this.config.status_icons !== false ? html`<span class="status-icon">${getStatusIcon(train)}</span>` : ''}
+                ${train.delay_minutes > 0 ? html`<span class="delay-text">+${train.delay_minutes}m</span>` : ''}
               </span>
             </div>
           `)}

--- a/src/styles.js
+++ b/src/styles.js
@@ -217,6 +217,18 @@ export const styles = css`
     gap: 4px;
   }
 
+  .train-row-compact .status .status-icon {
+    display: flex;
+    align-items: center;
+    line-height: 1;
+  }
+
+  .train-row-compact .status .delay-text {
+    display: flex;
+    align-items: center;
+    line-height: 1;
+  }
+
   .train-row-compact.on-time .status {
     color: var(--status-on-time);
   }


### PR DESCRIPTION
Resolves misalignment issue where emoji status icons and delay text (+Xm) were not properly aligned when displayed together. Wrapped each element in separate span containers to leverage flexbox alignment.

Changes:
- Wrap status icon in .status-icon span
- Wrap delay text in .delay-text span
- Add CSS rules for proper vertical alignment with line-height: 1

https://claude.ai/code/session_01N7HAX4KotUfsZhuBjMgkxp