### PR TITLE
Fix compact view column alignment using CSS grid

### DIFF
--- a/dist/my-rail-commute-card.js
+++ b/dist/my-rail-commute-card.js
@@ -237,8 +237,8 @@ const b=globalThis,x=t=>t,C=b.trustedTypes,A=C?C.createPolicy("lit-html",{create
   }
 
   .train-row-compact {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 60px 1fr 70px;
     align-items: center;
     padding: 8px var(--card-padding);
     border-bottom: 1px solid var(--divider-color, #e0e0e0);
@@ -257,23 +257,20 @@ const b=globalThis,x=t=>t,C=b.trustedTypes,A=C?C.createPolicy("lit-html",{create
   .train-row-compact .time {
     font-size: 1.1rem;
     font-weight: 500;
-    flex: 0 0 auto;
-    min-width: 60px;
   }
 
   .train-row-compact .platform {
     font-size: 0.9rem;
     color: var(--secondary-text-color, #757575);
-    flex: 1;
     text-align: center;
   }
 
   .train-row-compact .status {
     font-size: 0.9rem;
     font-weight: 500;
-    flex: 0 0 auto;
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 4px;
   }
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -221,8 +221,8 @@ export const styles = css`
   }
 
   .train-row-compact {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 60px 1fr 70px;
     align-items: center;
     padding: 8px var(--card-padding);
     border-bottom: 1px solid var(--divider-color, #e0e0e0);
@@ -241,23 +241,20 @@ export const styles = css`
   .train-row-compact .time {
     font-size: 1.1rem;
     font-weight: 500;
-    flex: 0 0 auto;
-    min-width: 60px;
   }
 
   .train-row-compact .platform {
     font-size: 0.9rem;
     color: var(--secondary-text-color, #757575);
-    flex: 1;
     text-align: center;
   }
 
   .train-row-compact .status {
     font-size: 0.9rem;
     font-weight: 500;
-    flex: 0 0 auto;
     display: flex;
     align-items: center;
+    justify-content: flex-end;
     gap: 4px;
   }
 


### PR DESCRIPTION
Replaced flexbox with `display: grid` and `grid-template-columns: 60px 1fr 70px` on `.train-row-compact` so the time, platform, and status columns have fixed widths across all rows. Previously the auto-width status column caused the platform column to shift left/right between rows depending on status content (e.g. just "✓" vs "⚠️ +5m"), breaking visual alignment.

Also adds `justify-content: flex-end` to the status cell so its content is consistently right-aligned, and removes the now-redundant flex properties from the time, platform and status child elements.

https://claude.ai/code/session_01RhWJnNGgzLZBrXTrmtV4pY