### PR TITLE
Fix disruption banner to read has_disruption attribute from integration

### DIFF
--- a/src/my-rail-commute-card.js
+++ b/src/my-rail-commute-card.js
@@ -168,15 +168,8 @@ class MyRailCommuteCard extends LitElement {
       this._trains = sortTrains(this._trains);
     }
 
-    // Detect disruption: from disruption_entity if configured, otherwise auto-detect from train data
-    if (this.config.disruption_entity) {
-      const disruptionEntity = hass.states[this.config.disruption_entity];
-      this._hasDisruption = disruptionEntity?.state === 'on';
-    } else {
-      this._hasDisruption = this._trains.some(
-        train => train.is_cancelled || train.delay_minutes >= 10
-      );
-    }
+    // Detect disruption from the integration's has_disruption attribute
+    this._hasDisruption = summaryEntity.attributes.has_disruption === 'Yes';
 
     // Filter trains
     if (this._trains && this._trains.length > 0) {


### PR DESCRIPTION
Replace auto-detection logic (delay/cancellation thresholds) and the separate disruption_entity config with a direct read of summaryEntity.attributes.has_disruption === 'Yes', so the integration is the sole source of truth for disruption state.

https://claude.ai/code/session_01Udv27eoPJoGqGNLXgei2f4