### PR TITLE
fix: handle both 'Yes' and 'on' for has_disruption attribute

### DIFF
--- a/src/my-rail-commute-card.js
+++ b/src/my-rail-commute-card.js
@@ -169,7 +169,9 @@ class MyRailCommuteCard extends LitElement {
     }
 
     // Detect disruption from the integration's has_disruption attribute
-    this._hasDisruption = summaryEntity.attributes.has_disruption === 'Yes';
+    // The value can be 'Yes' or 'on' depending on the integration/HA version
+    const disruption = summaryEntity.attributes.has_disruption;
+    this._hasDisruption = disruption === 'Yes' || disruption === 'on';
 
     // Filter trains
     if (this._trains && this._trains.length > 0) {


### PR DESCRIPTION
HA binary sensors can report disruption state as either 'Yes' or 'on' depending on the integration version. Previously only 'Yes' was matched, causing disruption to go undetected when the attribute value is 'on'.

https://claude.ai/code/session_01B1oCdLZZAZjKu8w4UZ24o8