### PR TITLE
Drive disruption banner from status sensor instead of binary has_disr…

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -286,14 +286,14 @@ class MyRailCommuteCardEditor extends LitElement {
 
         <div class="option">
           <ha-entity-picker
-            label="Disruption Sensor (Optional)"
+            label="Status Sensor (Optional)"
             .hass=${this._hass}
-            .value=${this._config.disruption_entity || ''}
-            .includeDomains=${['binary_sensor']}
-            @value-changed=${this._disruptionEntityChanged}
+            .value=${this._config.status_entity || ''}
+            .includeDomains=${['sensor']}
+            @value-changed=${this._statusEntityChanged}
             allow-custom-entity
           ></ha-entity-picker>
-          <div class="info">Binary sensor for severe disruption detection</div>
+          <div class="info">Sensor whose state drives the disruption banner. Expected states: Normal, Minor Delays, Major Delays, Severe Disruption, Critical. Auto-discovered from the summary entity name if not set.</div>
         </div>
 
         <div class="switches">
@@ -437,11 +437,11 @@ class MyRailCommuteCardEditor extends LitElement {
     this._fireConfigChanged();
   }
 
-  _disruptionEntityChanged(ev) {
+  _statusEntityChanged(ev) {
     if (!this._config || !this._hass) {
       return;
     }
-    this._config = { ...this._config, disruption_entity: ev.detail.value };
+    this._config = { ...this._config, status_entity: ev.detail.value };
     this._fireConfigChanged();
   }
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -71,6 +71,21 @@ export const styles = css`
     border-left-color: rgba(0, 0, 0, 0.2);
   }
 
+  .disruption-banner.disruption-major {
+    background: #e65100;
+    border-left-color: rgba(0, 0, 0, 0.25);
+  }
+
+  .disruption-banner.disruption-severe {
+    background: var(--status-major-delay);
+    border-left-color: rgba(0, 0, 0, 0.25);
+  }
+
+  .disruption-banner.disruption-critical {
+    background: #7f0000;
+    border-left-color: rgba(0, 0, 0, 0.35);
+  }
+
   .disruption-banner.disruption-clickable {
     cursor: pointer;
   }
@@ -121,6 +136,21 @@ export const styles = css`
 
   ha-card.departure-board .disruption-banner.disruption-minor {
     background: #e65100;
+    color: #ffcc00;
+  }
+
+  ha-card.departure-board .disruption-banner.disruption-major {
+    background: #bf360c;
+    color: #ffcc00;
+  }
+
+  ha-card.departure-board .disruption-banner.disruption-severe {
+    background: #b71c1c;
+    color: #ffcc00;
+  }
+
+  ha-card.departure-board .disruption-banner.disruption-critical {
+    background: #4a0000;
     color: #ffcc00;
   }
 


### PR DESCRIPTION
…uption

Replaces the multi-source disruption detection (has_disruption attribute, binary_sensor auto-discovery) with a single status sensor as the source of truth. The sensor state maps directly to the banner severity:

  Normal            → no banner
  Minor Delays      → orange banner  (disruption-minor)
  Major Delays      → deep-orange banner (disruption-major)
  Severe Disruption → red banner     (disruption-severe)
  Critical          → dark-red banner (disruption-critical)

The sensor is configured via `status_entity` in card config, or auto-discovered as `sensor.<base>_status` if not set. Clicking the banner opens the status sensor's more-info panel.

Removes _isActiveState helper, all binary_sensor auto-discovery, and the old disruption_entity editor field. Adds CSS for major/critical severity levels across both standard and departure-board themes.

https://claude.ai/code/session_01RxWWc1Ft7xy6jEZxZKjXgz