### PR TITLE
Fix show_journey_time toggle by calculating duration from arrival/dep…

### DIFF
--- a/src/my-rail-commute-card.js
+++ b/src/my-rail-commute-card.js
@@ -12,7 +12,8 @@ import {
   filterTrains,
   sortTrains,
   getTrainIcon,
-  shouldShowTrains
+  shouldShowTrains,
+  calculateJourneyDuration
 } from './utils.js';
 import './editor.js'; // Import editor to bundle it
 
@@ -574,6 +575,29 @@ class MyRailCommuteCard extends LitElement {
                          entity.attributes['Expected Departure'] ||
                          scheduledDep; // Fall back to scheduled if no expected
 
+      const scheduledArr = entity.attributes.scheduled_arrival ||
+                          entity.attributes.sta ||
+                          entity.attributes['Scheduled Arrival'] || null;
+
+      const estimatedArr = entity.attributes.estimated_arrival ||
+                          entity.attributes.eta ||
+                          entity.attributes['Estimated Arrival'] ||
+                          scheduledArr;
+
+      // Determine which departure time to use for journey duration calculation.
+      // Use expected_departure only if it contains a real time (HH:MM), not a status
+      // word like "Delayed" or "On Time".
+      const depIsValidTime = /\d{1,2}:\d{2}/.test(String(expectedDep));
+      const depForDuration = depIsValidTime ? expectedDep : scheduledDep;
+
+      // Flag as approximate when expected_departure was a non-time delay status word
+      // (e.g. "Delayed"). "On Time" and identical-to-scheduled values are not approximate.
+      const ON_TIME_RE = /^(on[\s-]?time|right\s*time)$/i;
+      const journeyTimeApprox = !depIsValidTime &&
+        !!expectedDep &&
+        expectedDep !== scheduledDep &&
+        !ON_TIME_RE.test(String(expectedDep).trim());
+
       const train = {
         train_id: entityId,
         scheduled_departure: scheduledDep,
@@ -602,7 +626,9 @@ class MyRailCommuteCard extends LitElement {
                      entity.attributes['Delay reason'] || '',
         calling_points: callingPoints,
         journey_duration: entity.attributes.journey_duration ||
-                         entity.attributes.duration || '',
+                         entity.attributes.duration ||
+                         calculateJourneyDuration(depForDuration, estimatedArr || scheduledArr),
+        journey_time_approx: journeyTimeApprox,
         service_type: entity.attributes.service_type ||
                      entity.attributes.type || ''
       };
@@ -893,7 +919,7 @@ class MyRailCommuteCard extends LitElement {
 
           ${showJourneyTime && train.journey_duration ? html`
             <div class="journey-time">
-              Journey time: ${train.journey_duration} mins
+              Journey time: ${train.journey_duration} mins${train.journey_time_approx ? '*' : ''}
             </div>
           ` : ''}
         </div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,6 +37,39 @@ export function formatTime(timeStr) {
 }
 
 /**
+ * Calculate journey duration in minutes between two time strings.
+ * Accepts ISO datetime strings or HH:MM / HH:MM:SS strings.
+ * Returns the duration as an integer, or null if either time cannot be parsed.
+ * @param {string} depTime - Departure time
+ * @param {string} arrTime - Arrival time
+ * @returns {number|null} Duration in minutes
+ */
+export function calculateJourneyDuration(depTime, arrTime) {
+  if (!depTime || !arrTime) return null;
+
+  // Try ISO datetime parsing first
+  const depDate = new Date(depTime);
+  const arrDate = new Date(arrTime);
+  if (!isNaN(depDate.getTime()) && !isNaN(arrDate.getTime())) {
+    const diff = Math.round((arrDate - depDate) / 60000);
+    return diff > 0 ? diff : null;
+  }
+
+  // Fall back to HH:MM string parsing
+  const depMatch = String(depTime).match(/(\d{1,2}):(\d{2})/);
+  const arrMatch = String(arrTime).match(/(\d{1,2}):(\d{2})/);
+  if (depMatch && arrMatch) {
+    let depMins = parseInt(depMatch[1], 10) * 60 + parseInt(depMatch[2], 10);
+    let arrMins = parseInt(arrMatch[1], 10) * 60 + parseInt(arrMatch[2], 10);
+    if (arrMins < depMins) arrMins += 1440; // handle midnight crossing
+    const diff = arrMins - depMins;
+    return diff > 0 ? diff : null;
+  }
+
+  return null;
+}
+
+/**
  * Get relative time string (e.g., "2 minutes ago")
  * @param {string} timestamp - ISO timestamp
  * @returns {string} Relative time string


### PR DESCRIPTION
…arture times

The toggle was a no-op because it relied on a journey_duration attribute that the integration does not provide. Duration is now calculated from scheduled_arrival/ estimated_arrival and scheduled_departure/expected_departure. An asterisk is appended when the departure time is an unknown-delay status word (e.g. "Delayed") and the scheduled departure was used as a proxy.

https://claude.ai/code/session_01K5dx8BRgdb7NhM5Pio5qRj