### PR TITLE
fix: guard estimated_arrival status text before calculating journey duration

### DIFF
--- a/src/my-rail-commute-card.js
+++ b/src/my-rail-commute-card.js
@@ -412,6 +412,12 @@ class MyRailCommuteCard extends LitElement {
         expectedDep !== scheduledDep &&
         !ON_TIME_RE.test(String(expectedDep).trim());
 
+      // Use estimated_arrival only when it contains a real HH:MM time. The National
+      // Rail API can return "On time" (or similar status text) in the et field, which
+      // is truthy but unparseable. Fall back to scheduledArr in that case.
+      const arrIsValidTime = /\d{1,2}:\d{2}/.test(String(estimatedArr));
+      const arrForDuration = arrIsValidTime ? estimatedArr : scheduledArr;
+
       const train = {
         train_id: entityId,
         scheduled_departure: scheduledDep,
@@ -441,7 +447,7 @@ class MyRailCommuteCard extends LitElement {
         calling_points: callingPoints,
         journey_duration: entity.attributes.journey_duration ||
                          entity.attributes.duration ||
-                         calculateJourneyDuration(depForDuration, estimatedArr || scheduledArr),
+                         calculateJourneyDuration(depForDuration, arrForDuration),
         journey_time_approx: journeyTimeApprox,
         service_type: entity.attributes.service_type ||
                      entity.attributes.type || ''


### PR DESCRIPTION
The National Rail API returns "On time" (or similar status words) in the
et field of calling points, which the integration passes through as
estimated_arrival. This string is truthy so `estimatedArr || scheduledArr`
resolved to "On time" rather than falling back to the valid scheduledArr
HH:MM time. calculateJourneyDuration then failed to parse it and returned
null, leaving train.journey_duration null and preventing the journey time
from rendering even when the toggle was on.

Apply the same valid-time guard already used for the departure side:
check that estimatedArr contains \d{1,2}:\d{2} before using it, and fall
back to scheduledArr otherwise. This mirrors the depIsValidTime /
depForDuration pattern introduced in acb84d3.

https://claude.ai/code/session_01EoGYCzFXVYcf5cVwFLC8hu