### PR TITLE
fix: only trigger release workflow on stable releases, not pre-releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 permissions:
   contents: write


### PR DESCRIPTION
Changes `types: [published]` to `types: [released]` so the build and
asset upload workflow skips pre-releases and runs only for full releases.

https://claude.ai/code/session_01S4tTUh472wRvTFKTUax6k2