### PR TITLE
Bump version to 1.0.5, update CHANGELOG and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.5] - 2026-04-11
+
+### Added
+- Release workflow to attach built JS as a release asset
+- Show "Entity not found" in card UI when entity is missing
+
+### Fixed
+- Fixed show_journey_time toggle by calculating duration from arrival/departure times
+- Guard estimated_arrival status text before calculating journey duration
+- Compute journey_duration in all_trains data path
+- Consistent error handling in formatTime and getRelativeTime utils
+- Only trigger release workflow on stable releases, not pre-releases
+- Fixed visual editor dropdowns for HA 2026.4 compatibility
+
+## [1.0.4] - 2026-03-17
+
+### Fixed
+- Resolved high, medium, and low-severity bugs in card component
+- Delay banner no longer bleeds through when reversing a route
+
 ## [1.0.3] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ colors:
 | `show_operator` | boolean | true | Show train operator |
 | `show_calling_points` | boolean | false | Show calling points list |
 | `show_delay_reason` | boolean | true | Show delay reasons |
-| `show_journey_time` | boolean | false | Show journey duration |
+| `show_journey_time` | boolean | false | Show journey duration (* shown if delayed) |
 | `max_calling_points` | number | 3 | Max calling points to display |
 | `hide_on_time_trains` | boolean | false | Only show delayed/cancelled trains |
 | `only_show_disrupted` | boolean | false | Only show when disruption sensor is on |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-rail-commute-card",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-rail-commute-card",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-rail-commute-card",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "A custom Lovelace card for Home Assistant that displays My Rail Commute departure information",
   "type": "module",
   "main": "dist/my-rail-commute-card.js",

--- a/src/my-rail-commute-card.js
+++ b/src/my-rail-commute-card.js
@@ -18,7 +18,7 @@ import {
 import './editor.js'; // Import editor to bundle it
 
 console.info(
-  '%c MY-RAIL-COMMUTE-CARD \n%c Version 1.0.0 ',
+  '%c MY-RAIL-COMMUTE-CARD \n%c Version 1.0.5 ',
   'color: cyan; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: dimgray',
 );


### PR DESCRIPTION
- Add CHANGELOG entries for 1.0.4 (bug fixes) and 1.0.5 (new features/fixes)
- Bump version to 1.0.5 in package.json, package-lock.json, and console banner
- Update show_journey_time README description to note * shown if delayed

https://claude.ai/code/session_014cJSoL9NaAwo6HUwtPL8fB