### PR TITLE
Add expandable history panel with day-by-day reliability timeline

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -328,6 +328,34 @@ class MyRailCommuteCardEditor extends LitElement {
           ></ha-textfield>
         </div>
 
+        <!-- Historical Reliability -->
+        <div class="section-header">Historical Reliability</div>
+
+        <div class="switches">
+          <ha-formfield label="Show History Panel">
+            <ha-switch
+              .checked=${this._config.show_history_panel === true}
+              @change=${this._toggleChanged('show_history_panel')}
+            ></ha-switch>
+          </ha-formfield>
+        </div>
+
+        <div class="info">When enabled, a chart-line button appears in the footer. Tap it to expand a panel showing on-time % KPIs and a colour-coded day-by-day timeline.</div>
+
+        ${this._config.show_history_panel ? html`
+          <div class="option" style="margin-top: 12px;">
+            <span class="native-select-label">History Window</span>
+            <div class="native-select-container">
+              <select @change=${this._historyDaysChanged}>
+                <option value="7" ?selected=${(this._config.history_days || 7) === 7}>Last 7 days</option>
+                <option value="14" ?selected=${(this._config.history_days || 7) === 14}>Last 14 days</option>
+                <option value="30" ?selected=${(this._config.history_days || 7) === 30}>Last 30 days</option>
+              </select>
+            </div>
+            <div class="info">Number of days shown in the day-by-day timeline.</div>
+          </div>
+        ` : ''}
+
         <!-- Advanced Options -->
         <div class="section-header">Advanced Options</div>
 
@@ -538,6 +566,12 @@ class MyRailCommuteCardEditor extends LitElement {
       ...this._config,
       hold_action: { action: ev.target.value }
     };
+    this._fireConfigChanged();
+  }
+
+  _historyDaysChanged(ev) {
+    if (!this._config || !this._hass) return;
+    this._config = { ...this._config, history_days: parseInt(ev.target.value, 10) };
     this._fireConfigChanged();
   }
 

--- a/src/my-rail-commute-card.js
+++ b/src/my-rail-commute-card.js
@@ -13,7 +13,8 @@ import {
   sortTrains,
   getTrainIcon,
   shouldShowTrains,
-  calculateJourneyDuration
+  calculateJourneyDuration,
+  getReliabilityClass
 } from './utils.js';
 import './editor.js'; // Import editor to bundle it
 
@@ -40,6 +41,9 @@ class MyRailCommuteCard extends LitElement {
       _entityNotFound: { type: Boolean },
       _returnEntityId: { type: String },
       _showReturn: { type: Boolean },
+      _historyPanelOpen: { type: Boolean },
+      _histRelAttrs: { type: Object },
+      _histDelAttrs: { type: Object },
     };
   }
 
@@ -63,6 +67,9 @@ class MyRailCommuteCard extends LitElement {
     this._returnEntityId = null;
     this._showReturn = false;
     this._returnEntityCacheKey = null;
+    this._historyPanelOpen = false;
+    this._histRelAttrs = null;
+    this._histDelAttrs = null;
   }
 
   setConfig(config) {
@@ -97,6 +104,8 @@ class MyRailCommuteCard extends LitElement {
       compact_height: false,
       show_animations: true,
       status_icons: true,
+      show_history_panel: false,
+      history_days: 7,
       ...config
     };
 
@@ -308,6 +317,18 @@ class MyRailCommuteCard extends LitElement {
       }
     }
 
+    // Auto-discover historical sensors when history panel is enabled
+    if (this.config.show_history_panel) {
+      const histBase = this.config.entity
+        .replace('sensor.', '')
+        .replace('_summary', '')
+        .replace('_commute_summary', '');
+      const histRelEntity = hass.states[`sensor.${histBase}_historical_reliability`];
+      const histDelEntity = hass.states[`sensor.${histBase}_historical_delays`];
+      this._histRelAttrs = histRelEntity ? histRelEntity.attributes : null;
+      this._histDelAttrs = histDelEntity ? histDelEntity.attributes : null;
+    }
+
     // Filter trains
     if (this._trains && this._trains.length > 0) {
       this._trains = filterTrains(this._trains, this.config);
@@ -339,6 +360,10 @@ class MyRailCommuteCard extends LitElement {
   _toggleReturn() {
     this._showReturn = !this._showReturn;
     if (this._hass) this.hass = this._hass;
+  }
+
+  _toggleHistoryPanel() {
+    this._historyPanelOpen = !this._historyPanelOpen;
   }
 
   _getTrainsFromIndividualSensors(hass, entityId) {
@@ -611,15 +636,133 @@ class MyRailCommuteCard extends LitElement {
   }
 
   _renderFooter() {
-    if (this.config.show_last_updated === false) return '';
+    const showLastUpdated = this.config.show_last_updated === true;
+    const showHistoryPanel = this.config.show_history_panel === true;
+
+    if (!showLastUpdated && !showHistoryPanel) return '';
 
     return html`
       <div class="card-footer">
-        <span class="last-updated">
-          Last updated: ${getRelativeTime(this._lastUpdated)}
-        </span>
+        ${showLastUpdated ? html`
+          <span class="last-updated">
+            Last updated: ${getRelativeTime(this._lastUpdated)}
+          </span>
+        ` : html`<span></span>`}
+        ${showHistoryPanel ? html`
+          <button
+            class="history-toggle ${this._historyPanelOpen ? 'active' : ''}"
+            @click="${this._toggleHistoryPanel}"
+            title="${this._historyPanelOpen ? 'Hide reliability history' : 'Show reliability history'}"
+          >
+            <ha-icon icon="mdi:chart-line"></ha-icon>
+          </button>
+        ` : ''}
       </div>
     `;
+  }
+
+  _renderHistoryPanel() {
+    if (!this.config.show_history_panel || !this._historyPanelOpen) return '';
+
+    const rel = this._histRelAttrs;
+    const del = this._histDelAttrs;
+
+    if (!rel && !del) {
+      return html`
+        <div class="history-panel">
+          <div class="history-empty">No reliability data available yet — check back after a few updates.</div>
+        </div>
+      `;
+    }
+
+    const histDays = Math.min(this.config.history_days || 7, 30);
+    const breakdown = rel?.daily_breakdown || [];
+    const recentDays = breakdown.slice(-histDays);
+
+    const todayPct = rel?.on_time_pct_today ?? null;
+    const sevenDayPct = rel?.on_time_pct_7day ?? null;
+    const thirtyDayPct = rel?.on_time_pct_30day ?? null;
+    const avgDelay7d = del?.avg_delay_7day ?? null;
+    const bestDay = del?.best_day ?? null;
+    const worstDay = del?.worst_day ?? null;
+
+    return html`
+      <div class="history-panel">
+        <div class="history-kpis">
+          ${this._renderKpiPill('Today', todayPct, '%', false)}
+          ${this._renderKpiPill('7-day', sevenDayPct, '%', false)}
+          ${this._renderKpiPill('30-day', thirtyDayPct, '%', false)}
+          ${this._renderKpiPill('Avg delay', avgDelay7d, ' min', true)}
+        </div>
+
+        ${recentDays.length > 0 ? html`
+          <div class="history-days">
+            ${recentDays.map(day => this._renderDaySquare(day))}
+          </div>
+        ` : ''}
+
+        ${bestDay || worstDay ? html`
+          <div class="history-bestworst">
+            ${bestDay ? html`
+              <span class="history-best">
+                <ha-icon icon="mdi:thumb-up-outline"></ha-icon>
+                Best: ${this._formatHistoryDate(bestDay.date)} (${bestDay.on_time_pct}%)
+              </span>
+            ` : html`<span></span>`}
+            ${worstDay ? html`
+              <span class="history-worst">
+                <ha-icon icon="mdi:thumb-down-outline"></ha-icon>
+                Worst: ${this._formatHistoryDate(worstDay.date)} (${worstDay.on_time_pct}%)
+              </span>
+            ` : ''}
+          </div>
+        ` : ''}
+      </div>
+    `;
+  }
+
+  _renderKpiPill(label, value, unit, isDelay) {
+    const cls = isDelay ? 'kpi-neutral' : getReliabilityClass(value);
+    const display = value !== null && value !== undefined ? `${value}${unit}` : '—';
+    return html`
+      <div class="kpi-pill ${cls}">
+        <span class="kpi-value">${display}</span>
+        <span class="kpi-label">${label}</span>
+      </div>
+    `;
+  }
+
+  _renderDaySquare(day) {
+    const pct = day.on_time_pct;
+    let cls = 'day-sq-nodata';
+    if (pct !== null && pct !== undefined) {
+      if (pct >= 90) cls = 'day-sq-good';
+      else if (pct >= 70) cls = 'day-sq-moderate';
+      else cls = 'day-sq-poor';
+    }
+
+    const [year, month, dayNum] = day.date.split('-').map(Number);
+    const date = new Date(year, month - 1, dayNum);
+    const dayName = date.toLocaleDateString('en-GB', { weekday: 'short' });
+    const pctLabel = pct !== null && pct !== undefined ? `${Math.round(pct)}%` : '—';
+    const tooltip = pct !== null && pct !== undefined
+      ? `${dayName} ${dayNum}: ${pct}% on-time${day.avg_delay_minutes ? `, avg ${day.avg_delay_minutes} min late` : ''}`
+      : `${dayName} ${dayNum}: No data`;
+
+    return html`
+      <div class="day-sq ${cls}" title="${tooltip}">
+        <span class="day-sq-label">${dayName}</span>
+        <span class="day-sq-pct">${pctLabel}</span>
+      </div>
+    `;
+  }
+
+  _formatHistoryDate(dateStr) {
+    if (!dateStr) return '';
+    const [year, month, day] = dateStr.split('-').map(Number);
+    return new Date(year, month - 1, day).toLocaleDateString('en-GB', {
+      weekday: 'short', day: 'numeric', month: 'short'
+    });
   }
 
   _renderFull() {
@@ -634,6 +777,7 @@ class MyRailCommuteCard extends LitElement {
           ${this._trains.map(train => this._renderTrainRow(train))}
         </div>
 
+        ${this._renderHistoryPanel()}
         ${this._renderFooter()}
       </ha-card>
     `;
@@ -731,6 +875,7 @@ class MyRailCommuteCard extends LitElement {
           })}
         </div>
 
+        ${this._renderHistoryPanel()}
         ${this._renderFooter()}
       </ha-card>
     `;

--- a/src/styles.js
+++ b/src/styles.js
@@ -589,8 +589,177 @@ export const styles = css`
     border-top: 1px solid var(--divider-color, #e0e0e0);
     font-size: 0.8rem;
     color: var(--secondary-text-color, #757575);
-    text-align: center;
     background: var(--card-background-color, #fff);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .last-updated {
+    flex: 1;
+    text-align: center;
+  }
+
+  .history-toggle {
+    background: none;
+    border: 1px solid var(--divider-color, #e0e0e0);
+    border-radius: 50%;
+    width: 28px;
+    height: 28px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--secondary-text-color, #757575);
+    padding: 0;
+    flex-shrink: 0;
+    transition: background 0.2s, color 0.2s, border-color 0.2s;
+    --mdc-icon-size: 16px;
+  }
+
+  .history-toggle:hover {
+    background: var(--secondary-background-color, #f5f5f5);
+  }
+
+  .history-toggle.active {
+    background: var(--primary-color, #03a9f4);
+    color: #fff;
+    border-color: var(--primary-color, #03a9f4);
+  }
+
+  /* ==================== HISTORY PANEL ==================== */
+
+  .history-panel {
+    border-top: 1px solid var(--divider-color, #e0e0e0);
+    padding: 12px var(--card-padding);
+    background: var(--secondary-background-color, #f5f5f5);
+  }
+
+  .history-kpis {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+
+  .kpi-pill {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 8px 4px;
+    border-radius: 8px;
+    background: var(--card-background-color, #fff);
+    border: 1px solid var(--divider-color, #e0e0e0);
+    min-width: 0;
+  }
+
+  .kpi-value {
+    font-size: 1rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .kpi-label {
+    font-size: 0.68rem;
+    color: var(--secondary-text-color, #757575);
+    margin-top: 2px;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .kpi-pill.kpi-good .kpi-value { color: var(--status-on-time); }
+  .kpi-pill.kpi-moderate .kpi-value { color: var(--status-minor-delay); }
+  .kpi-pill.kpi-poor .kpi-value { color: var(--status-major-delay); }
+  .kpi-pill.kpi-neutral .kpi-value { color: var(--secondary-text-color, #757575); }
+
+  .history-days {
+    display: flex;
+    gap: 3px;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    margin-bottom: 10px;
+    scrollbar-width: none;
+  }
+
+  .history-days::-webkit-scrollbar {
+    display: none;
+  }
+
+  .day-sq {
+    flex: 1 1 0;
+    min-width: 26px;
+    border-radius: 4px;
+    padding: 5px 2px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    cursor: default;
+  }
+
+  .day-sq-label {
+    font-size: 0.58rem;
+    color: rgba(255,255,255,0.85);
+    font-weight: 500;
+    line-height: 1.1;
+  }
+
+  .day-sq-pct {
+    font-size: 0.6rem;
+    color: rgba(255,255,255,0.95);
+    font-weight: 600;
+    line-height: 1.1;
+  }
+
+  .day-sq.day-sq-good { background: var(--status-on-time, #4caf50); }
+  .day-sq.day-sq-moderate { background: var(--status-minor-delay, #ff9800); }
+  .day-sq.day-sq-poor { background: var(--status-major-delay, #f44336); }
+
+  .day-sq.day-sq-nodata {
+    background: var(--divider-color, #e0e0e0);
+  }
+
+  .day-sq.day-sq-nodata .day-sq-label {
+    color: var(--secondary-text-color, #9e9e9e);
+  }
+
+  .day-sq.day-sq-nodata .day-sq-pct {
+    color: var(--secondary-text-color, #9e9e9e);
+  }
+
+  .history-bestworst {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.78rem;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .history-best {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    color: var(--status-on-time, #4caf50);
+  }
+
+  .history-worst {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    color: var(--status-major-delay, #f44336);
+  }
+
+  .history-best ha-icon,
+  .history-worst ha-icon {
+    --mdc-icon-size: 14px;
+  }
+
+  .history-empty {
+    font-size: 0.85rem;
+    color: var(--secondary-text-color, #757575);
+    text-align: center;
+    padding: 8px 0;
   }
 
   /* ==================== EMPTY STATE ==================== */

--- a/src/utils.js
+++ b/src/utils.js
@@ -378,3 +378,15 @@ export function truncateText(text, maxLength) {
   if (!text || text.length <= maxLength) return text;
   return text.substring(0, maxLength - 1) + '…';
 }
+
+/**
+ * Get CSS class for a reliability percentage value
+ * @param {number|null} pct - On-time percentage (0-100) or null
+ * @returns {string} CSS class name
+ */
+export function getReliabilityClass(pct) {
+  if (pct === null || pct === undefined) return 'kpi-neutral';
+  if (pct >= 90) return 'kpi-good';
+  if (pct >= 70) return 'kpi-moderate';
+  return 'kpi-poor';
+}


### PR DESCRIPTION
Implements Proposal C from the reliability display design: an opt-in collapsible panel (toggle button in card footer) showing on-time % KPI pills for today/7-day/30-day, a colour-coded day-square timeline (green ≥90%, amber 70-89%, red <70%), and best/worst day callouts. Available in full and compact views.

New config options: show_history_panel (default false), history_days (7/14/30, default 7). Historical sensors are auto-discovered by naming convention. Requires the daily_breakdown attribute on sensor.<device>_historical_reliability.

https://claude.ai/code/session_01WBpjamXuFgTzAbkfixRUWu