### PR TITLE
Add multi-destination grouped view for all-departures mode

### DIFF
--- a/dist/my-rail-commute-card.js
+++ b/dist/my-rail-commute-card.js
@@ -14,12 +14,12 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
-const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{createHTML:t=>t}):void 0,S="$lit$",A=`lit$${Math.random().toFixed(9).slice(2)}$`,k="?"+A,T=`<${k}>`,P=document,O=()=>P.createComment(""),D=t=>null===t||"object"!=typeof t&&"function"!=typeof t,R=Array.isArray,j="[ \t\n\f\r]",N=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,z=/-->/g,I=/>/g,M=RegExp(`>|${j}(?:([^\\s"'>=/]+)(${j}*=${j}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),H=/'/g,U=/"/g,L=/^(?:script|style|textarea|title)$/i,q=(t=>(e,...i)=>({_$litType$:t,strings:e,values:i}))(1),B=Symbol.for("lit-noChange"),F=Symbol.for("lit-nothing"),V=new WeakMap,W=P.createTreeWalker(P,129);function K(t,e){if(!R(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==E?E.createHTML(e):e}const J=(t,e)=>{const i=t.length-1,s=[];let o,r=2===e?"<svg>":3===e?"<math>":"",n=N;for(let e=0;e<i;e++){const i=t[e];let a,c,l=-1,d=0;for(;d<i.length&&(n.lastIndex=d,c=n.exec(i),null!==c);)d=n.lastIndex,n===N?"!--"===c[1]?n=z:void 0!==c[1]?n=I:void 0!==c[2]?(L.test(c[2])&&(o=RegExp("</"+c[2],"g")),n=M):void 0!==c[3]&&(n=M):n===M?">"===c[0]?(n=o??N,l=-1):void 0===c[1]?l=-2:(l=n.lastIndex-c[2].length,a=c[1],n=void 0===c[3]?M:'"'===c[3]?U:H):n===U||n===H?n=M:n===z||n===I?n=N:(n=M,o=void 0);const h=n===M&&t[e+1].startsWith("/>")?" ":"";r+=n===N?i+T:l>=0?(s.push(a),i.slice(0,l)+S+i.slice(l)+A+h):i+A+(-2===l?e:h)}return[K(t,r+(t[i]||"<?>")+(2===e?"</svg>":3===e?"</math>":"")),s]};class G{constructor({strings:t,_$litType$:e},i){let s;this.parts=[];let o=0,r=0;const n=t.length-1,a=this.parts,[c,l]=J(t,e);if(this.el=G.createElement(c,i),W.currentNode=this.el.content,2===e||3===e){const t=this.el.content.firstChild;t.replaceWith(...t.childNodes)}for(;null!==(s=W.nextNode())&&a.length<n;){if(1===s.nodeType){if(s.hasAttributes())for(const t of s.getAttributeNames())if(t.endsWith(S)){const e=l[r++],i=s.getAttribute(t).split(A),n=/([.?@])?(.*)/.exec(e);a.push({type:1,index:o,name:n[2],strings:i,ctor:"."===n[1]?tt:"?"===n[1]?et:"@"===n[1]?it:Q}),s.removeAttribute(t)}else t.startsWith(A)&&(a.push({type:6,index:o}),s.removeAttribute(t));if(L.test(s.tagName)){const t=s.textContent.split(A),e=t.length-1;if(e>0){s.textContent=C?C.emptyScript:"";for(let i=0;i<e;i++)s.append(t[i],O()),W.nextNode(),a.push({type:2,index:++o});s.append(t[e],O())}}}else if(8===s.nodeType)if(s.data===k)a.push({type:2,index:o});else{let t=-1;for(;-1!==(t=s.data.indexOf(A,t+1));)a.push({type:7,index:o}),t+=A.length-1}o++}}static createElement(t,e){const i=P.createElement("template");return i.innerHTML=t,i}}function Y(t,e,i=t,s){if(e===B)return e;let o=void 0!==s?i._$Co?.[s]:i._$Cl;const r=D(e)?void 0:e._$litDirective$;return o?.constructor!==r&&(o?._$AO?.(!1),void 0===r?o=void 0:(o=new r(t),o._$AT(t,i,s)),void 0!==s?(i._$Co??=[])[s]=o:i._$Cl=o),void 0!==o&&(e=Y(t,o._$AS(t,e.values),o,s)),e}class X{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:i}=this._$AD,s=(t?.creationScope??P).importNode(e,!0);W.currentNode=s;let o=W.nextNode(),r=0,n=0,a=i[0];for(;void 0!==a;){if(r===a.index){let e;2===a.type?e=new Z(o,o.nextSibling,this,t):1===a.type?e=new a.ctor(o,a.name,a.strings,this,t):6===a.type&&(e=new st(o,this,t)),this._$AV.push(e),a=i[++n]}r!==a?.index&&(o=W.nextNode(),r++)}return W.currentNode=P,s}p(t){let e=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(t,i,e),e+=i.strings.length-2):i._$AI(t[e])),e++}}class Z{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,e,i,s){this.type=2,this._$AH=F,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=i,this.options=s,this._$Cv=s?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===t?.nodeType&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=Y(this,t,e),D(t)?t===F||null==t||""===t?(this._$AH!==F&&this._$AR(),this._$AH=F):t!==this._$AH&&t!==B&&this._(t):void 0!==t._$litType$?this.$(t):void 0!==t.nodeType?this.T(t):(t=>R(t)||"function"==typeof t?.[Symbol.iterator])(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==F&&D(this._$AH)?this._$AA.nextSibling.data=t:this.T(P.createTextNode(t)),this._$AH=t}$(t){const{values:e,_$litType$:i}=t,s="number"==typeof i?this._$AC(t):(void 0===i.el&&(i.el=G.createElement(K(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===s)this._$AH.p(e);else{const t=new X(s,this),i=t.u(this.options);t.p(e),this.T(i),this._$AH=t}}_$AC(t){let e=V.get(t.strings);return void 0===e&&V.set(t.strings,e=new G(t)),e}k(t){R(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let i,s=0;for(const o of t)s===e.length?e.push(i=new Z(this.O(O()),this.O(O()),this,this.options)):i=e[s],i._$AI(o),s++;s<e.length&&(this._$AR(i&&i._$AB.nextSibling,s),e.length=s)}_$AR(t=this._$AA.nextSibling,e){for(this._$AP?.(!1,!0,e);t!==this._$AB;){const e=x(t).nextSibling;x(t).remove(),t=e}}setConnected(t){void 0===this._$AM&&(this._$Cv=t,this._$AP?.(t))}}class Q{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,i,s,o){this.type=1,this._$AH=F,this._$AN=void 0,this.element=t,this.name=e,this._$AM=s,this.options=o,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=F}_$AI(t,e=this,i,s){const o=this.strings;let r=!1;if(void 0===o)t=Y(this,t,e,0),r=!D(t)||t!==this._$AH&&t!==B,r&&(this._$AH=t);else{const s=t;let n,a;for(t=o[0],n=0;n<o.length-1;n++)a=Y(this,s[i+n],e,n),a===B&&(a=this._$AH[n]),r||=!D(a)||a!==this._$AH[n],a===F?t=F:t!==F&&(t+=(a??"")+o[n+1]),this._$AH[n]=a}r&&!s&&this.j(t)}j(t){t===F?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class tt extends Q{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===F?void 0:t}}class et extends Q{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==F)}}class it extends Q{constructor(t,e,i,s,o){super(t,e,i,s,o),this.type=5}_$AI(t,e=this){if((t=Y(this,t,e,0)??F)===B)return;const i=this._$AH,s=t===F&&i!==F||t.capture!==i.capture||t.once!==i.once||t.passive!==i.passive,o=t!==F&&(i===F||s);s&&this.element.removeEventListener(this.name,this,i),o&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}}class st{constructor(t,e,i){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(t){Y(this,t)}}const ot=w.litHtmlPolyfillSupport;ot?.(G,Z),(w.litHtmlVersions??=[]).push("3.3.2");const rt=globalThis;
+const w=globalThis,x=t=>t,C=w.trustedTypes,k=C?C.createPolicy("lit-html",{createHTML:t=>t}):void 0,E="$lit$",S=`lit$${Math.random().toFixed(9).slice(2)}$`,A="?"+S,T=`<${A}>`,D=document,P=()=>D.createComment(""),O=t=>null===t||"object"!=typeof t&&"function"!=typeof t,j=Array.isArray,R="[ \t\n\f\r]",M=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,N=/-->/g,z=/>/g,I=RegExp(`>|${R}(?:([^\\s"'>=/]+)(${R}*=${R}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`,"g"),H=/'/g,U=/"/g,L=/^(?:script|style|textarea|title)$/i,B=(t=>(e,...i)=>({_$litType$:t,strings:e,values:i}))(1),q=Symbol.for("lit-noChange"),F=Symbol.for("lit-nothing"),V=new WeakMap,W=D.createTreeWalker(D,129);function G(t,e){if(!j(t)||!t.hasOwnProperty("raw"))throw Error("invalid template strings array");return void 0!==k?k.createHTML(e):e}const K=(t,e)=>{const i=t.length-1,s=[];let o,r=2===e?"<svg>":3===e?"<math>":"",n=M;for(let e=0;e<i;e++){const i=t[e];let a,c,l=-1,d=0;for(;d<i.length&&(n.lastIndex=d,c=n.exec(i),null!==c);)d=n.lastIndex,n===M?"!--"===c[1]?n=N:void 0!==c[1]?n=z:void 0!==c[2]?(L.test(c[2])&&(o=RegExp("</"+c[2],"g")),n=I):void 0!==c[3]&&(n=I):n===I?">"===c[0]?(n=o??M,l=-1):void 0===c[1]?l=-2:(l=n.lastIndex-c[2].length,a=c[1],n=void 0===c[3]?I:'"'===c[3]?U:H):n===U||n===H?n=I:n===N||n===z?n=M:(n=I,o=void 0);const h=n===I&&t[e+1].startsWith("/>")?" ":"";r+=n===M?i+T:l>=0?(s.push(a),i.slice(0,l)+E+i.slice(l)+S+h):i+S+(-2===l?e:h)}return[G(t,r+(t[i]||"<?>")+(2===e?"</svg>":3===e?"</math>":"")),s]};class J{constructor({strings:t,_$litType$:e},i){let s;this.parts=[];let o=0,r=0;const n=t.length-1,a=this.parts,[c,l]=K(t,e);if(this.el=J.createElement(c,i),W.currentNode=this.el.content,2===e||3===e){const t=this.el.content.firstChild;t.replaceWith(...t.childNodes)}for(;null!==(s=W.nextNode())&&a.length<n;){if(1===s.nodeType){if(s.hasAttributes())for(const t of s.getAttributeNames())if(t.endsWith(E)){const e=l[r++],i=s.getAttribute(t).split(S),n=/([.?@])?(.*)/.exec(e);a.push({type:1,index:o,name:n[2],strings:i,ctor:"."===n[1]?tt:"?"===n[1]?et:"@"===n[1]?it:Q}),s.removeAttribute(t)}else t.startsWith(S)&&(a.push({type:6,index:o}),s.removeAttribute(t));if(L.test(s.tagName)){const t=s.textContent.split(S),e=t.length-1;if(e>0){s.textContent=C?C.emptyScript:"";for(let i=0;i<e;i++)s.append(t[i],P()),W.nextNode(),a.push({type:2,index:++o});s.append(t[e],P())}}}else if(8===s.nodeType)if(s.data===A)a.push({type:2,index:o});else{let t=-1;for(;-1!==(t=s.data.indexOf(S,t+1));)a.push({type:7,index:o}),t+=S.length-1}o++}}static createElement(t,e){const i=D.createElement("template");return i.innerHTML=t,i}}function Y(t,e,i=t,s){if(e===q)return e;let o=void 0!==s?i._$Co?.[s]:i._$Cl;const r=O(e)?void 0:e._$litDirective$;return o?.constructor!==r&&(o?._$AO?.(!1),void 0===r?o=void 0:(o=new r(t),o._$AT(t,i,s)),void 0!==s?(i._$Co??=[])[s]=o:i._$Cl=o),void 0!==o&&(e=Y(t,o._$AS(t,e.values),o,s)),e}class X{constructor(t,e){this._$AV=[],this._$AN=void 0,this._$AD=t,this._$AM=e}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(t){const{el:{content:e},parts:i}=this._$AD,s=(t?.creationScope??D).importNode(e,!0);W.currentNode=s;let o=W.nextNode(),r=0,n=0,a=i[0];for(;void 0!==a;){if(r===a.index){let e;2===a.type?e=new Z(o,o.nextSibling,this,t):1===a.type?e=new a.ctor(o,a.name,a.strings,this,t):6===a.type&&(e=new st(o,this,t)),this._$AV.push(e),a=i[++n]}r!==a?.index&&(o=W.nextNode(),r++)}return W.currentNode=D,s}p(t){let e=0;for(const i of this._$AV)void 0!==i&&(void 0!==i.strings?(i._$AI(t,i,e),e+=i.strings.length-2):i._$AI(t[e])),e++}}class Z{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(t,e,i,s){this.type=2,this._$AH=F,this._$AN=void 0,this._$AA=t,this._$AB=e,this._$AM=i,this.options=s,this._$Cv=s?.isConnected??!0}get parentNode(){let t=this._$AA.parentNode;const e=this._$AM;return void 0!==e&&11===t?.nodeType&&(t=e.parentNode),t}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(t,e=this){t=Y(this,t,e),O(t)?t===F||null==t||""===t?(this._$AH!==F&&this._$AR(),this._$AH=F):t!==this._$AH&&t!==q&&this._(t):void 0!==t._$litType$?this.$(t):void 0!==t.nodeType?this.T(t):(t=>j(t)||"function"==typeof t?.[Symbol.iterator])(t)?this.k(t):this._(t)}O(t){return this._$AA.parentNode.insertBefore(t,this._$AB)}T(t){this._$AH!==t&&(this._$AR(),this._$AH=this.O(t))}_(t){this._$AH!==F&&O(this._$AH)?this._$AA.nextSibling.data=t:this.T(D.createTextNode(t)),this._$AH=t}$(t){const{values:e,_$litType$:i}=t,s="number"==typeof i?this._$AC(t):(void 0===i.el&&(i.el=J.createElement(G(i.h,i.h[0]),this.options)),i);if(this._$AH?._$AD===s)this._$AH.p(e);else{const t=new X(s,this),i=t.u(this.options);t.p(e),this.T(i),this._$AH=t}}_$AC(t){let e=V.get(t.strings);return void 0===e&&V.set(t.strings,e=new J(t)),e}k(t){j(this._$AH)||(this._$AH=[],this._$AR());const e=this._$AH;let i,s=0;for(const o of t)s===e.length?e.push(i=new Z(this.O(P()),this.O(P()),this,this.options)):i=e[s],i._$AI(o),s++;s<e.length&&(this._$AR(i&&i._$AB.nextSibling,s),e.length=s)}_$AR(t=this._$AA.nextSibling,e){for(this._$AP?.(!1,!0,e);t!==this._$AB;){const e=x(t).nextSibling;x(t).remove(),t=e}}setConnected(t){void 0===this._$AM&&(this._$Cv=t,this._$AP?.(t))}}class Q{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(t,e,i,s,o){this.type=1,this._$AH=F,this._$AN=void 0,this.element=t,this.name=e,this._$AM=s,this.options=o,i.length>2||""!==i[0]||""!==i[1]?(this._$AH=Array(i.length-1).fill(new String),this.strings=i):this._$AH=F}_$AI(t,e=this,i,s){const o=this.strings;let r=!1;if(void 0===o)t=Y(this,t,e,0),r=!O(t)||t!==this._$AH&&t!==q,r&&(this._$AH=t);else{const s=t;let n,a;for(t=o[0],n=0;n<o.length-1;n++)a=Y(this,s[i+n],e,n),a===q&&(a=this._$AH[n]),r||=!O(a)||a!==this._$AH[n],a===F?t=F:t!==F&&(t+=(a??"")+o[n+1]),this._$AH[n]=a}r&&!s&&this.j(t)}j(t){t===F?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,t??"")}}class tt extends Q{constructor(){super(...arguments),this.type=3}j(t){this.element[this.name]=t===F?void 0:t}}class et extends Q{constructor(){super(...arguments),this.type=4}j(t){this.element.toggleAttribute(this.name,!!t&&t!==F)}}class it extends Q{constructor(t,e,i,s,o){super(t,e,i,s,o),this.type=5}_$AI(t,e=this){if((t=Y(this,t,e,0)??F)===q)return;const i=this._$AH,s=t===F&&i!==F||t.capture!==i.capture||t.once!==i.once||t.passive!==i.passive,o=t!==F&&(i===F||s);s&&this.element.removeEventListener(this.name,this,i),o&&this.element.addEventListener(this.name,this,t),this._$AH=t}handleEvent(t){"function"==typeof this._$AH?this._$AH.call(this.options?.host??this.element,t):this._$AH.handleEvent(t)}}class st{constructor(t,e,i){this.element=t,this.type=6,this._$AN=void 0,this._$AM=e,this.options=i}get _$AU(){return this._$AM._$AU}_$AI(t){Y(this,t)}}const ot=w.litHtmlPolyfillSupport;ot?.(J,Z),(w.litHtmlVersions??=[]).push("3.3.2");const rt=globalThis;
 /**
  * @license
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
- */class nt extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,i)=>{const s=i?.renderBefore??e;let o=s._$litPart$;if(void 0===o){const t=i?.renderBefore??null;s._$litPart$=o=new Z(e.insertBefore(O(),t),t,void 0,i??{})}return o._$AI(t),o})(e,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return B}}nt._$litElement$=!0,nt.finalized=!0,rt.litElementHydrateSupport?.({LitElement:nt});const at=rt.litElementPolyfillSupport;at?.({LitElement:nt}),(rt.litElementVersions??=[]).push("4.2.2");const ct=r`
+ */class nt extends ${constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){const t=super.createRenderRoot();return this.renderOptions.renderBefore??=t.firstChild,t}update(t){const e=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(t),this._$Do=((t,e,i)=>{const s=i?.renderBefore??e;let o=s._$litPart$;if(void 0===o){const t=i?.renderBefore??null;s._$litPart$=o=new Z(e.insertBefore(P(),t),t,void 0,i??{})}return o._$AI(t),o})(e,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return q}}nt._$litElement$=!0,nt.finalized=!0,rt.litElementHydrateSupport?.({LitElement:nt});const at=rt.litElementPolyfillSupport;at?.({LitElement:nt}),(rt.litElementVersions??=[]).push("4.2.2");const ct=r`
   :host {
     --status-on-time: var(--custom-on-time-color, #4caf50);
     --status-minor-delay: var(--custom-minor-delay-color, #ff9800);
@@ -209,6 +209,67 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
 
   .card-content {
     padding: 0;
+  }
+
+  /* ==================== DESTINATION GROUPS (multi-destination mode) ==================== */
+
+  .destination-group {
+    border-top: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
+  }
+
+  .destination-group:first-child {
+    border-top: none;
+  }
+
+  .destination-group-header {
+    display: flex;
+    align-items: center;
+    padding: 8px var(--card-padding) 4px;
+    gap: 6px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--secondary-text-color, #757575);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: var(--secondary-background-color, rgba(0, 0, 0, 0.03));
+    border-bottom: 1px solid var(--divider-color, rgba(0, 0, 0, 0.08));
+  }
+
+  .destination-group-header .dest-arrow {
+    opacity: 0.5;
+    font-size: 0.9rem;
+  }
+
+  .destination-group-header .dest-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .destination-group-header .dest-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--status-on-time, #4caf50);
+  }
+
+  .destination-group-header .dest-status-dot.status-critical,
+  .destination-group-header .dest-status-dot.status-severe {
+    background: var(--status-cancelled, #d32f2f);
+  }
+
+  .destination-group-header .dest-status-dot.status-major {
+    background: var(--status-major-delay, #f44336);
+  }
+
+  .destination-group-header .dest-status-dot.status-minor {
+    background: var(--status-minor-delay, #ff9800);
+  }
+
+  .destination-group-header .dest-status-dot.status-normal {
+    background: var(--status-on-time, #4caf50);
   }
 
   /* ==================== FULL VIEW ==================== */
@@ -1034,7 +1095,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
   }
 
 
-`;function lt(t){if(!t||"unknown"===t||"Unknown"===t)return"—";const e=String(t).trim();if(!e)return"—";const i=e.match(/(\d{1,2}):(\d{2})(?::\d{2})?/);if(i)return`${i[1].padStart(2,"0")}:${i[2]}`;try{const t=new Date(e);return isNaN(t.getTime())?(console.warn("formatTime: unparseable value:",e),"—"):t.toLocaleTimeString("en-GB",{hour:"2-digit",minute:"2-digit",hour12:!1})}catch(t){return console.warn("formatTime: could not parse time value:",e,t),"—"}}function dt(t,e){if(!t||!e)return null;try{const i=new Date(t),s=new Date(e);if(!isNaN(i.getTime())&&!isNaN(s.getTime())){const t=Math.round((s-i)/6e4);return t>0?t:null}}catch(i){console.warn("calculateJourneyDuration: could not parse as dates:",t,e,i)}const i=String(t).match(/(\d{1,2}):(\d{2})/),s=String(e).match(/(\d{1,2}):(\d{2})/);if(i&&s){let t=60*parseInt(i[1],10)+parseInt(i[2],10),e=60*parseInt(s[1],10)+parseInt(s[2],10);e<t&&(e+=1440);const o=e-t;return o>0?o:null}return null}function ht(t){return!(!t||!t.expected_departure)&&(t.expected_departure!==t.scheduled_departure&&!/\d{1,2}:\d{2}/.test(t.expected_departure))}function pt(t){return t?t.is_cancelled?"cancelled":t.is_no_service?"no-service":t.delay_minutes>=10?"major-delay":t.delay_minutes>0||ht(t)?"minor-delay":"on-time":"unknown"}function ut(t,e=!0){return e&&t?t.is_cancelled?"❌":t.is_no_service?"⊗":t.delay_minutes>=10?"🔴":t.delay_minutes>0||ht(t)?"⚠️":"✓":""}function _t(t){return t?t.is_cancelled?"Cancelled":t.is_no_service?"No service":t.delay_minutes>0?`Delayed ${t.delay_minutes} min${1!==t.delay_minutes?"s":""}`:ht(t)?"Delayed":"On time":"Unknown"}customElements.define("my-rail-commute-card-editor",class extends nt{static get properties(){return{hass:{type:Object},_config:{type:Object}}}static get styles(){return r`
+`;function lt(t){if(!t||"unknown"===t||"Unknown"===t)return"—";const e=String(t).trim();if(!e)return"—";const i=e.match(/(\d{1,2}):(\d{2})(?::\d{2})?/);if(i)return`${i[1].padStart(2,"0")}:${i[2]}`;try{const t=new Date(e);return isNaN(t.getTime())?(console.warn("formatTime: unparseable value:",e),"—"):t.toLocaleTimeString("en-GB",{hour:"2-digit",minute:"2-digit",hour12:!1})}catch(t){return console.warn("formatTime: could not parse time value:",e,t),"—"}}function dt(t,e){if(!t||!e)return null;try{const i=new Date(t),s=new Date(e);if(!isNaN(i.getTime())&&!isNaN(s.getTime())){const t=Math.round((s-i)/6e4);return t>0?t:null}}catch(i){console.warn("calculateJourneyDuration: could not parse as dates:",t,e,i)}const i=String(t).match(/(\d{1,2}):(\d{2})/),s=String(e).match(/(\d{1,2}):(\d{2})/);if(i&&s){let t=60*parseInt(i[1],10)+parseInt(i[2],10),e=60*parseInt(s[1],10)+parseInt(s[2],10);e<t&&(e+=1440);const o=e-t;return o>0?o:null}return null}function ht(t){return!(!t||!t.expected_departure)&&(t.expected_departure!==t.scheduled_departure&&!/\d{1,2}:\d{2}/.test(t.expected_departure))}function pt(t){return t?t.is_cancelled?"cancelled":t.is_no_service?"no-service":t.delay_minutes>=10?"major-delay":t.delay_minutes>0||ht(t)?"minor-delay":"on-time":"unknown"}function ut(t,e=!0){return e&&t?t.is_cancelled?"❌":t.is_no_service?"⊗":t.delay_minutes>=10?"🔴":t.delay_minutes>0||ht(t)?"⚠️":"✓":""}function _t(t){return t?t.is_cancelled?"Cancelled":t.is_no_service?"No service":t.delay_minutes>0?`Delayed ${t.delay_minutes} min${1!==t.delay_minutes?"s":""}`:ht(t)?"Delayed":"On time":"Unknown"}function mt(t){if(!t)return"";if(t.length<=12)return t;const e={London:"Ldn",Street:"St",Bridge:"Bdg",Junction:"Jn",Central:"Cen",International:"Intl",Station:"Stn",Road:"Rd",Cross:"X",Park:"Pk"};let i=t;for(const[t,s]of Object.entries(e))i=i.replace(new RegExp(t,"g"),s);return i.length>12&&(i=i.substring(0,11)+"…"),i}function gt(t){const e=new Map;for(const i of t){const t=i.destination&&String(i.destination).trim()||"Unknown";e.has(t)||e.set(t,[]),e.get(t).push(i)}return e}function ft(t){if(!t||0===t.length)return"normal";if(t.some(t=>t.is_cancelled))return"critical";const e=Math.max(...t.map(t=>t.delay_minutes||0));return e>=15?"severe":e>=10?"major":e>0?"minor":"normal"}customElements.define("my-rail-commute-card-editor",class extends nt{static get properties(){return{hass:{type:Object},_config:{type:Object}}}static get styles(){return r`
       .card-config {
         padding: 16px;
       }
@@ -1133,7 +1194,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
         color: var(--secondary-text-color);
         margin-top: 4px;
       }
-    `}setConfig(t){this._config={...t},this.requestUpdate()}set hass(t){this._hass=t,this.requestUpdate()}get hass(){return this._hass}_filterSummaryEntities(t){const e=this._hass.states[t.entity_id];if("my_rail_commute"===e?.attributes?.integration)return!0;const i=t.entity_id.toLowerCase();return i.endsWith("_summary")||i.includes("commute")||i.includes("rail")||i.includes("train")}render(){return this._hass&&this._config?q`
+    `}setConfig(t){this._config={...t},this.requestUpdate()}set hass(t){this._hass=t,this.requestUpdate()}get hass(){return this._hass}_filterSummaryEntities(t){const e=this._hass.states[t.entity_id];if("my_rail_commute"===e?.attributes?.integration)return!0;const i=t.entity_id.toLowerCase();return i.endsWith("_summary")||i.includes("commute")||i.includes("rail")||i.includes("train")}render(){return this._hass&&this._config?B`
       <div class="card-config">
         <!-- Basic Configuration -->
         <div class="section-header">Basic Configuration</div>
@@ -1278,6 +1339,15 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
             ></ha-switch>
           </ha-formfield>
 
+          ${this._isMultiDestinationSensor()?B`
+            <ha-formfield label="Group Trains by Destination">
+              <ha-switch
+                .checked=${!1!==this._config.group_by_destination}
+                @change=${this._toggleChanged("group_by_destination")}
+              ></ha-switch>
+            </ha-formfield>
+          `:""}
+
         </div>
 
         <!-- Filtering Options -->
@@ -1328,7 +1398,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
 
         <div class="info">When enabled, a chart-line button appears in the footer. Tap it to expand a panel showing on-time % KPIs and a colour-coded day-by-day timeline.</div>
 
-        ${this._config.show_history_panel?q`
+        ${this._config.show_history_panel?B`
           <div class="option" style="margin-top: 12px;">
             <span class="native-select-label">History Window</span>
             <div class="native-select-container">
@@ -1392,7 +1462,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
           </div>
         </div>
 
-        ${"url"===this._config.tap_action?.action?q`
+        ${"url"===this._config.tap_action?.action?B`
           <div class="option">
             <ha-textfield
               label="URL Path"
@@ -1402,7 +1472,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
           </div>
         `:""}
 
-        ${"navigate"===this._config.tap_action?.action?q`
+        ${"navigate"===this._config.tap_action?.action?B`
           <div class="option">
             <ha-textfield
               label="Navigation Path"
@@ -1423,12 +1493,12 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
           </div>
         </div>
       </div>
-    `:q``}_entityChanged(t){this._config&&this._hass&&(this._config={...this._config,entity:t.detail.value},this._fireConfigChanged())}_titleChanged(t){this._config&&this._hass&&(this._config={...this._config,title:t.target.value},this._fireConfigChanged())}_viewChanged(t){this._config&&this._hass&&(this._config={...this._config,view:t.target.value},this._fireConfigChanged())}_themeChanged(t){this._config&&this._hass&&(this._config={...this._config,theme:t.target.value},this._fireConfigChanged())}_fontSizeChanged(t){this._config&&this._hass&&(this._config={...this._config,font_size:t.target.value},this._fireConfigChanged())}_toggleChanged(t){return e=>{this._config&&this._hass&&(this._config={...this._config,[t]:e.target.checked},this._fireConfigChanged())}}_minDelayChanged(t){if(!this._config||!this._hass)return;const e=parseInt(t.target.value,10)||0;this._config={...this._config,min_delay_to_show:e},this._fireConfigChanged()}_maxCallingPointsChanged(t){if(!this._config||!this._hass)return;const e=parseInt(t.target.value,10)||3;this._config={...this._config,max_calling_points:e},this._fireConfigChanged()}_statusEntityChanged(t){this._config&&this._hass&&(this._config={...this._config,status_entity:t.detail.value},this._fireConfigChanged())}_refreshIntervalChanged(t){if(!this._config||!this._hass)return;const e=parseInt(t.target.value,10)||60;this._config={...this._config,refresh_interval:e},this._fireConfigChanged()}_tapActionChanged(t){this._config&&this._hass&&(this._config={...this._config,tap_action:{action:t.target.value}},this._fireConfigChanged())}_urlPathChanged(t){this._config&&this._hass&&(this._config={...this._config,tap_action:{...this._config.tap_action,url_path:t.target.value}},this._fireConfigChanged())}_navigationPathChanged(t){this._config&&this._hass&&(this._config={...this._config,tap_action:{...this._config.tap_action,navigation_path:t.target.value}},this._fireConfigChanged())}_holdActionChanged(t){this._config&&this._hass&&(this._config={...this._config,hold_action:{action:t.target.value}},this._fireConfigChanged())}_historyDaysChanged(t){this._config&&this._hass&&(this._config={...this._config,history_days:parseInt(t.target.value,10)},this._fireConfigChanged())}_fireConfigChanged(){const t=new CustomEvent("config-changed",{detail:{config:this._config},bubbles:!0,composed:!0});this.dispatchEvent(t)}}),console.info("%c MY-RAIL-COMMUTE-CARD \n%c Version 1.0.5 ","color: cyan; font-weight: bold; background: black","color: white; font-weight: bold; background: dimgray");class mt extends nt{static get properties(){return{hass:{type:Object},config:{type:Object},_trains:{type:Array},_origin:{type:String},_destination:{type:String},_lastUpdated:{type:String},_hasDisruption:{type:Boolean},_disruptionSeverity:{type:String},_disruptionMessage:{type:String},_resolvedStatusEntityId:{type:String},_loading:{type:Boolean},_entityNotFound:{type:Boolean},_returnEntityId:{type:String},_showReturn:{type:Boolean},_historyPanelOpen:{type:Boolean},_histRelAttrs:{type:Object},_histDelAttrs:{type:Object}}}static get styles(){return ct}constructor(){super(),this._trains=[],this._origin="",this._destination="",this._lastUpdated="",this._hasDisruption=!1,this._disruptionSeverity="",this._disruptionMessage="",this._resolvedStatusEntityId="",this._loading=!0,this._entityNotFound=!1,this._toastTimer=null,this._toastElement=null,this._returnEntityId=null,this._showReturn=!1,this._returnEntityCacheKey=null,this._historyPanelOpen=!1,this._histRelAttrs=null,this._histDelAttrs=null}setConfig(t){if(!t)throw new Error("Invalid configuration");if(!t.entity&&""!==t.entity)throw new Error("Please select a rail commute summary sensor");this.config={view:"full",theme:"auto",show_header:!0,show_route:!0,show_last_updated:!1,show_platform:!0,show_operator:!0,show_calling_points:!1,show_delay_reason:!0,show_journey_time:!1,show_service_type:!1,max_calling_points:3,hide_on_time_trains:!1,only_show_disrupted:!1,min_delay_to_show:0,auto_refresh:!0,refresh_interval:60,card_style:"departure-board",font_size:"medium",compact_height:!1,show_animations:!0,status_icons:!0,show_history_panel:!1,history_days:7,...t},t.colors&&(t.colors.on_time&&this.style.setProperty("--custom-on-time-color",t.colors.on_time),t.colors.minor_delay&&this.style.setProperty("--custom-minor-delay-color",t.colors.minor_delay),t.colors.major_delay&&this.style.setProperty("--custom-major-delay-color",t.colors.major_delay),t.colors.cancelled&&this.style.setProperty("--custom-cancelled-color",t.colors.cancelled)),t.theme&&"auto"!==t.theme&&this.setAttribute("theme",t.theme),t.font_size&&this.setAttribute("font-size",t.font_size),!1===t.show_animations&&this.setAttribute("no-animations","")}set hass(t){if(this._hass=t,!this.config.entity)return this._loading=!1,void(this._trains=[]);const e=t.states[this.config.entity];if(!e)return console.error("my-rail-commute-card: entity not found:",this.config.entity),this._entityNotFound=!0,this._loading=!1,void(this._trains=[]);this._entityNotFound=!1;const i=e.attributes.origin_name||e.attributes.origin||e.attributes.from_station||"",s=e.attributes.destination_name||e.attributes.destination||e.attributes.to_station||"",o=`${i}|${s}`;o!==this._returnEntityCacheKey?(this._returnEntityCacheKey=o,this._returnEntityId=this._findReturnEntity(t,i,s)):this._returnEntityId&&!t.states[this._returnEntityId]&&(this._returnEntityCacheKey=null,this._returnEntityId=this._findReturnEntity(t,i,s)),this._showReturn&&!this._returnEntityId&&(this._showReturn=!1);const r=this._showReturn&&this._returnEntityId?this._returnEntityId:this.config.entity,n=t.states[r];if(!n)return this._loading=!1,void(this._trains=[]);if(n.attributes.all_trains&&n.attributes.all_trains.length>0){const t=r.replace("sensor.","").replace("_summary","").replace("_commute_summary","");this._trains=n.attributes.all_trains.map((e,i)=>{const s=null!=e.train_number&&""!==e.train_number?String(e.train_number).toLowerCase().replace(/[^a-z0-9]/g,"_"):String(i+1),o=e.scheduled_departure,r=e.expected_departure,n=e.scheduled_arrival,a=e.estimated_arrival,c=/\d{1,2}:\d{2}/.test(String(r||"")),l=c?r:o,d=!c&&!!r&&r!==o&&!/^(on[\s-]?time|right\s*time)$/i.test(String(r||"").trim()),h=/\d{1,2}:\d{2}/.test(String(a||""))?a:n;return{...e,journey_duration:e.journey_duration||dt(l,h),journey_time_approx:e.journey_time_approx||d,train_id:`sensor.${t}_train_${s}`}})}else this._trains=this._getTrainsFromIndividualSensors(t,r);var a;let c;if(this._origin=this._showReturn?s:i,this._destination=this._showReturn?i:s,this._lastUpdated=n.attributes.last_updated||n.last_updated||n.last_changed||"",this._trains&&this._trains.length>0&&(this._trains=(a=this._trains)&&0!==a.length?[...a].sort((t,e)=>{const i=new Date(t.scheduled_departure).getTime(),s=new Date(e.scheduled_departure).getTime(),o=!isNaN(i),r=!isNaN(s);return o||r?o?r?i-s:-1:1:0}):[]),this._hasDisruption=!1,this._disruptionSeverity="",this._disruptionMessage="",this._resolvedStatusEntityId="",this._showReturn&&this._returnEntityId){const e=`sensor.${this._returnEntityId.replace("sensor.","").replace("_summary","").replace("_commute_summary","")}_status`;t.states[e]&&(c=e)}else if(c=this.config.status_entity,!c){const e=`sensor.${this.config.entity.replace("sensor.","").replace("_summary","").replace("_commute_summary","")}_status`;t.states[e]&&(c=e)}if(c){this._resolvedStatusEntityId=c;const e=t.states[c];if(e){const t=(e.state||"").toLowerCase().trim();"normal"!==t&&"unknown"!==t&&"unavailable"!==t&&""!==t&&(this._hasDisruption=!0,t.includes("critical")?this._disruptionSeverity="critical":t.includes("severe")?this._disruptionSeverity="severe":t.includes("major")?this._disruptionSeverity="major":this._disruptionSeverity="minor",this._disruptionMessage=e.attributes.message||e.attributes.reason||e.attributes.disruption_message||"")}}if(this.config.show_history_panel){const e=this.config.entity.replace("sensor.","").replace("_summary","").replace("_commute_summary",""),i=t.states[`sensor.${e}_historical_reliability`],s=t.states[`sensor.${e}_historical_delays`];i||s||console.warn("my-rail-commute-card: show_history_panel is enabled but no history sensors were found.",`Expected: sensor.${e}_historical_reliability / sensor.${e}_historical_delays`),this._histRelAttrs=i?i.attributes:null,this._histDelAttrs=s?s.attributes:null}this._trains&&this._trains.length>0&&(this._trains=function(t,e){if(!t||0===t.length)return[];let i=[...t];return e.hide_on_time_trains&&(i=i.filter(t=>t.is_cancelled||t.is_no_service||t.delay_minutes>0||ht(t))),e.min_delay_to_show>0&&(i=i.filter(t=>t.is_cancelled||t.is_no_service||ht(t)||t.delay_minutes>=e.min_delay_to_show)),i}(this._trains,this.config)),this._loading=!1,this.requestUpdate()}_findReturnEntity(t,e,i){if(!e||!i)return null;const s=e.toLowerCase().trim(),o=i.toLowerCase().trim();for(const[e,i]of Object.entries(t.states)){if(e===this.config.entity)continue;if(!i.attributes)continue;const t=i.attributes;if(!(t.all_trains||t.origin_name||t.origin||t.from_station))continue;const r=(t.origin_name||t.origin||t.from_station||"").toLowerCase().trim(),n=(t.destination_name||t.destination||t.to_station||"").toLowerCase().trim();if(r&&n&&(r===o&&n===s))return e}return null}_toggleReturn(){this._showReturn=!this._showReturn,this._hass&&(this.hass=this._hass)}_toggleHistoryPanel(){this._historyPanelOpen=!this._historyPanelOpen}_getTrainsFromIndividualSensors(t,e){const i=(e||this.config.entity).replace("sensor.","").replace("_summary","").replace("_commute_summary",""),s=[`sensor.${i}_train_`,`sensor.${i}_train`,`sensor.${i.replace(/_/g,"-")}_train_`,`sensor.${i.replace(/_/g,"")}_train_`];let o=[];for(const e of s){const i=Object.keys(t.states).filter(t=>t.startsWith(e));if(i.length>0){o=i;break}}o.sort((t,e)=>parseInt(t.match(/train[_-]?(\d+)$/i)?.[1]||"0",10)-parseInt(e.match(/train[_-]?(\d+)$/i)?.[1]||"0",10));const r=o.map(e=>{const i=t.states[e];if(!i)return console.warn(`my-rail-commute-card: train sensor not found: ${e}`),null;let s=i.attributes.calling_points||i.attributes.stops||i.attributes.calling_at||i.attributes["Calling at"]||[];"string"==typeof s&&(s=s.split(",").map(t=>t.trim()).filter(t=>t));const o=i.attributes.scheduled_departure||i.attributes.scheduled||i.attributes.departure||i.attributes.departure_time||i.attributes.std||i.attributes.aimed_departure_time||i.attributes["Scheduled Departure"]||i.state,r=i.attributes.expected_departure||i.attributes.expected||i.attributes.estimated||i.attributes.estimated_departure||i.attributes.etd||i.attributes.expected_arrival||i.attributes["Expected Departure"]||o,n=i.attributes.scheduled_arrival||i.attributes.sta||i.attributes["Scheduled Arrival"]||null,a=i.attributes.estimated_arrival||i.attributes.eta||i.attributes["Estimated Arrival"]||n,c=/\d{1,2}:\d{2}/.test(String(r)),l=c?r:o,d=!c&&!!r&&r!==o&&!/^(on[\s-]?time|right\s*time)$/i.test(String(r).trim()),h=/\d{1,2}:\d{2}/.test(String(a))?a:n;return{train_id:e,scheduled_departure:o,expected_departure:r,platform:i.attributes.platform||i.attributes.Platform||"",operator:i.attributes.operator||i.attributes.service_operator||i.attributes.Operator||"",is_cancelled:i.attributes.is_cancelled||i.attributes.cancelled||"Cancelled"===i.state||"Canceled"===i.state||!1,is_no_service:i.attributes.is_no_service||i.attributes.no_service||"No service"===i.state||"No Service"===i.state||!1,delay_minutes:parseInt(i.attributes.delay_minutes||i.attributes.delay||i.attributes.minutes_late||i.attributes["Delay minutes"]||"0",10),delay_reason:i.attributes.delay_reason||i.attributes.reason||i.attributes["Delay reason"]||"",calling_points:s,journey_duration:i.attributes.journey_duration||i.attributes.duration||dt(l,h),journey_time_approx:d,service_type:i.attributes.service_type||i.attributes.type||""}}).filter(t=>null!==t);return r}getCardSize(){const t=this.config.view||"full",e=this._trains?.length||0;switch(t){case"compact":return 1+Math.ceil(.5*e);case"next-only":return 3;default:return 2+e}}render(){if(!this.config.entity)return this._renderEmpty("No entity selected","Please select a rail commute summary sensor in the card configuration");if(this._loading)return this._renderLoading();if(t=this._hasDisruption,this.config.only_show_disrupted&&!t)return this._renderEmpty("No disruption detected","Trains will appear when there is disruption");var t;if(this._entityNotFound)return this._renderEmpty("Entity not found",`Cannot find entity: ${this.config.entity}`);if(!this._trains||0===this._trains.length)return this._renderEmpty();switch(this.config.view||"full"){case"compact":return this._renderCompact();case"next-only":return this._renderNextOnly();case"board":return this._renderBoard();default:return this._renderFull()}}_renderHeader(){const t=!1!==this.config.show_header,e=!1!==this.config.show_route;if(!t)return"";const i=String(this.config.title||"Rail Commute").replace(/<[^>]*>/g,"");return q`
+    `:B``}_entityChanged(t){this._config&&this._hass&&(this._config={...this._config,entity:t.detail.value},this._fireConfigChanged())}_titleChanged(t){this._config&&this._hass&&(this._config={...this._config,title:t.target.value},this._fireConfigChanged())}_viewChanged(t){this._config&&this._hass&&(this._config={...this._config,view:t.target.value},this._fireConfigChanged())}_themeChanged(t){this._config&&this._hass&&(this._config={...this._config,theme:t.target.value},this._fireConfigChanged())}_fontSizeChanged(t){this._config&&this._hass&&(this._config={...this._config,font_size:t.target.value},this._fireConfigChanged())}_toggleChanged(t){return e=>{this._config&&this._hass&&(this._config={...this._config,[t]:e.target.checked},this._fireConfigChanged())}}_minDelayChanged(t){if(!this._config||!this._hass)return;const e=parseInt(t.target.value,10)||0;this._config={...this._config,min_delay_to_show:e},this._fireConfigChanged()}_maxCallingPointsChanged(t){if(!this._config||!this._hass)return;const e=parseInt(t.target.value,10)||3;this._config={...this._config,max_calling_points:e},this._fireConfigChanged()}_statusEntityChanged(t){this._config&&this._hass&&(this._config={...this._config,status_entity:t.detail.value},this._fireConfigChanged())}_refreshIntervalChanged(t){if(!this._config||!this._hass)return;const e=parseInt(t.target.value,10)||60;this._config={...this._config,refresh_interval:e},this._fireConfigChanged()}_tapActionChanged(t){this._config&&this._hass&&(this._config={...this._config,tap_action:{action:t.target.value}},this._fireConfigChanged())}_urlPathChanged(t){this._config&&this._hass&&(this._config={...this._config,tap_action:{...this._config.tap_action,url_path:t.target.value}},this._fireConfigChanged())}_navigationPathChanged(t){this._config&&this._hass&&(this._config={...this._config,tap_action:{...this._config.tap_action,navigation_path:t.target.value}},this._fireConfigChanged())}_holdActionChanged(t){this._config&&this._hass&&(this._config={...this._config,hold_action:{action:t.target.value}},this._fireConfigChanged())}_historyDaysChanged(t){this._config&&this._hass&&(this._config={...this._config,history_days:parseInt(t.target.value,10)},this._fireConfigChanged())}_isMultiDestinationSensor(){if(!this._hass||!this._config?.entity)return!1;const t=this._hass.states[this._config.entity];return!0===t?.attributes?.multi_destination}_fireConfigChanged(){const t=new CustomEvent("config-changed",{detail:{config:this._config},bubbles:!0,composed:!0});this.dispatchEvent(t)}}),console.info("%c MY-RAIL-COMMUTE-CARD \n%c Version 1.0.5 ","color: cyan; font-weight: bold; background: black","color: white; font-weight: bold; background: dimgray");class yt extends nt{static get properties(){return{hass:{type:Object},config:{type:Object},_trains:{type:Array},_origin:{type:String},_destination:{type:String},_lastUpdated:{type:String},_hasDisruption:{type:Boolean},_disruptionSeverity:{type:String},_disruptionMessage:{type:String},_resolvedStatusEntityId:{type:String},_loading:{type:Boolean},_entityNotFound:{type:Boolean},_returnEntityId:{type:String},_showReturn:{type:Boolean},_historyPanelOpen:{type:Boolean},_histRelAttrs:{type:Object},_histDelAttrs:{type:Object},_isMultiDestination:{type:Boolean},_servicesByDestination:{type:Object}}}static get styles(){return ct}constructor(){super(),this._trains=[],this._origin="",this._destination="",this._lastUpdated="",this._hasDisruption=!1,this._disruptionSeverity="",this._disruptionMessage="",this._resolvedStatusEntityId="",this._loading=!0,this._entityNotFound=!1,this._toastTimer=null,this._toastElement=null,this._returnEntityId=null,this._showReturn=!1,this._returnEntityCacheKey=null,this._historyPanelOpen=!1,this._histRelAttrs=null,this._histDelAttrs=null,this._isMultiDestination=!1,this._servicesByDestination=null}setConfig(t){if(!t)throw new Error("Invalid configuration");if(!t.entity&&""!==t.entity)throw new Error("Please select a rail commute summary sensor");this.config={view:"full",theme:"auto",show_header:!0,show_route:!0,show_last_updated:!1,show_platform:!0,show_operator:!0,show_calling_points:!1,show_delay_reason:!0,show_journey_time:!1,show_service_type:!1,max_calling_points:3,hide_on_time_trains:!1,only_show_disrupted:!1,min_delay_to_show:0,auto_refresh:!0,refresh_interval:60,card_style:"departure-board",font_size:"medium",compact_height:!1,show_animations:!0,status_icons:!0,show_history_panel:!1,history_days:7,group_by_destination:!0,...t},t.colors&&(t.colors.on_time&&this.style.setProperty("--custom-on-time-color",t.colors.on_time),t.colors.minor_delay&&this.style.setProperty("--custom-minor-delay-color",t.colors.minor_delay),t.colors.major_delay&&this.style.setProperty("--custom-major-delay-color",t.colors.major_delay),t.colors.cancelled&&this.style.setProperty("--custom-cancelled-color",t.colors.cancelled)),t.theme&&"auto"!==t.theme&&this.setAttribute("theme",t.theme),t.font_size&&this.setAttribute("font-size",t.font_size),!1===t.show_animations&&this.setAttribute("no-animations","")}set hass(t){if(this._hass=t,!this.config.entity)return this._loading=!1,void(this._trains=[]);const e=t.states[this.config.entity];if(!e)return console.error("my-rail-commute-card: entity not found:",this.config.entity),this._entityNotFound=!0,this._loading=!1,void(this._trains=[]);this._entityNotFound=!1;const i=e.attributes.origin_name||e.attributes.origin||e.attributes.from_station||"",s=e.attributes.destination_name||e.attributes.destination||e.attributes.to_station||"",o=`${i}|${s}`;o!==this._returnEntityCacheKey?(this._returnEntityCacheKey=o,this._returnEntityId=this._findReturnEntity(t,i,s)):this._returnEntityId&&!t.states[this._returnEntityId]&&(this._returnEntityCacheKey=null,this._returnEntityId=this._findReturnEntity(t,i,s)),this._showReturn&&!this._returnEntityId&&(this._showReturn=!1);const r=this._showReturn&&this._returnEntityId?this._returnEntityId:this.config.entity,n=t.states[r];if(!n)return this._loading=!1,void(this._trains=[]);if(n.attributes.all_trains&&n.attributes.all_trains.length>0){const t=r.replace("sensor.","").replace("_summary","").replace("_commute_summary","");this._trains=n.attributes.all_trains.map((e,i)=>{const s=null!=e.train_number&&""!==e.train_number?String(e.train_number).toLowerCase().replace(/[^a-z0-9]/g,"_"):String(i+1),o=e.scheduled_departure,r=e.expected_departure,n=e.scheduled_arrival,a=e.estimated_arrival,c=/\d{1,2}:\d{2}/.test(String(r||"")),l=c?r:o,d=!c&&!!r&&r!==o&&!/^(on[\s-]?time|right\s*time)$/i.test(String(r||"").trim()),h=/\d{1,2}:\d{2}/.test(String(a||""))?a:n;return{...e,journey_duration:e.journey_duration||dt(l,h),journey_time_approx:e.journey_time_approx||d,train_id:`sensor.${t}_train_${s}`}})}else this._trains=this._getTrainsFromIndividualSensors(t,r);var a;let c;if(this._isMultiDestination=!0===n.attributes.multi_destination,this._servicesByDestination=n.attributes.services_by_destination||null,this._origin=this._showReturn?s:i,this._destination=this._isMultiDestination?null:this._showReturn?i:s,this._lastUpdated=n.attributes.last_updated||n.last_updated||n.last_changed||"",this._trains&&this._trains.length>0&&(this._trains=(a=this._trains)&&0!==a.length?[...a].sort((t,e)=>{const i=new Date(t.scheduled_departure).getTime(),s=new Date(e.scheduled_departure).getTime(),o=!isNaN(i),r=!isNaN(s);return o||r?o?r?i-s:-1:1:0}):[]),this._hasDisruption=!1,this._disruptionSeverity="",this._disruptionMessage="",this._resolvedStatusEntityId="",this._showReturn&&this._returnEntityId){const e=`sensor.${this._returnEntityId.replace("sensor.","").replace("_summary","").replace("_commute_summary","")}_status`;t.states[e]&&(c=e)}else if(c=this.config.status_entity,!c){const e=`sensor.${this.config.entity.replace("sensor.","").replace("_summary","").replace("_commute_summary","")}_status`;t.states[e]&&(c=e)}if(c){this._resolvedStatusEntityId=c;const e=t.states[c];if(e){const t=(e.state||"").toLowerCase().trim();"normal"!==t&&"unknown"!==t&&"unavailable"!==t&&""!==t&&(this._hasDisruption=!0,t.includes("critical")?this._disruptionSeverity="critical":t.includes("severe")?this._disruptionSeverity="severe":t.includes("major")?this._disruptionSeverity="major":this._disruptionSeverity="minor",this._disruptionMessage=e.attributes.message||e.attributes.reason||e.attributes.disruption_message||"")}}if(this.config.show_history_panel){const e=this.config.entity.replace("sensor.","").replace("_summary","").replace("_commute_summary",""),i=t.states[`sensor.${e}_historical_reliability`],s=t.states[`sensor.${e}_historical_delays`];i||s||console.warn("my-rail-commute-card: show_history_panel is enabled but no history sensors were found.",`Expected: sensor.${e}_historical_reliability / sensor.${e}_historical_delays`),this._histRelAttrs=i?i.attributes:null,this._histDelAttrs=s?s.attributes:null}this._trains&&this._trains.length>0&&(this._trains=function(t,e){if(!t||0===t.length)return[];let i=[...t];return e.hide_on_time_trains&&(i=i.filter(t=>t.is_cancelled||t.is_no_service||t.delay_minutes>0||ht(t))),e.min_delay_to_show>0&&(i=i.filter(t=>t.is_cancelled||t.is_no_service||ht(t)||t.delay_minutes>=e.min_delay_to_show)),i}(this._trains,this.config)),this._loading=!1,this.requestUpdate()}_findReturnEntity(t,e,i){if(!e||!i||this._isMultiDestination)return null;const s=e.toLowerCase().trim(),o=i.toLowerCase().trim();for(const[e,i]of Object.entries(t.states)){if(e===this.config.entity)continue;if(!i.attributes)continue;const t=i.attributes;if(!(t.all_trains||t.origin_name||t.origin||t.from_station))continue;const r=(t.origin_name||t.origin||t.from_station||"").toLowerCase().trim(),n=(t.destination_name||t.destination||t.to_station||"").toLowerCase().trim();if(r&&n&&(r===o&&n===s))return e}return null}_toggleReturn(){this._showReturn=!this._showReturn,this._hass&&(this.hass=this._hass)}_toggleHistoryPanel(){this._historyPanelOpen=!this._historyPanelOpen}_getTrainsFromIndividualSensors(t,e){const i=(e||this.config.entity).replace("sensor.","").replace("_summary","").replace("_commute_summary",""),s=[`sensor.${i}_train_`,`sensor.${i}_train`,`sensor.${i.replace(/_/g,"-")}_train_`,`sensor.${i.replace(/_/g,"")}_train_`];let o=[];for(const e of s){const i=Object.keys(t.states).filter(t=>t.startsWith(e));if(i.length>0){o=i;break}}o.sort((t,e)=>parseInt(t.match(/train[_-]?(\d+)$/i)?.[1]||"0",10)-parseInt(e.match(/train[_-]?(\d+)$/i)?.[1]||"0",10));const r=o.map(e=>{const i=t.states[e];if(!i)return console.warn(`my-rail-commute-card: train sensor not found: ${e}`),null;let s=i.attributes.calling_points||i.attributes.stops||i.attributes.calling_at||i.attributes["Calling at"]||[];"string"==typeof s&&(s=s.split(",").map(t=>t.trim()).filter(t=>t));const o=i.attributes.scheduled_departure||i.attributes.scheduled||i.attributes.departure||i.attributes.departure_time||i.attributes.std||i.attributes.aimed_departure_time||i.attributes["Scheduled Departure"]||i.state,r=i.attributes.expected_departure||i.attributes.expected||i.attributes.estimated||i.attributes.estimated_departure||i.attributes.etd||i.attributes.expected_arrival||i.attributes["Expected Departure"]||o,n=i.attributes.scheduled_arrival||i.attributes.sta||i.attributes["Scheduled Arrival"]||null,a=i.attributes.estimated_arrival||i.attributes.eta||i.attributes["Estimated Arrival"]||n,c=/\d{1,2}:\d{2}/.test(String(r)),l=c?r:o,d=!c&&!!r&&r!==o&&!/^(on[\s-]?time|right\s*time)$/i.test(String(r).trim()),h=/\d{1,2}:\d{2}/.test(String(a))?a:n;return{train_id:e,scheduled_departure:o,expected_departure:r,platform:i.attributes.platform||i.attributes.Platform||"",operator:i.attributes.operator||i.attributes.service_operator||i.attributes.Operator||"",is_cancelled:i.attributes.is_cancelled||i.attributes.cancelled||"Cancelled"===i.state||"Canceled"===i.state||!1,is_no_service:i.attributes.is_no_service||i.attributes.no_service||"No service"===i.state||"No Service"===i.state||!1,delay_minutes:parseInt(i.attributes.delay_minutes||i.attributes.delay||i.attributes.minutes_late||i.attributes["Delay minutes"]||"0",10),delay_reason:i.attributes.delay_reason||i.attributes.reason||i.attributes["Delay reason"]||"",calling_points:s,journey_duration:i.attributes.journey_duration||i.attributes.duration||dt(l,h),journey_time_approx:d,service_type:i.attributes.service_type||i.attributes.type||""}}).filter(t=>null!==t);return r}getCardSize(){const t=this.config.view||"full",e=this._trains?.length||0;switch(t){case"compact":return 1+Math.ceil(.5*e);case"next-only":return 3;default:return 2+e}}render(){if(!this.config.entity)return this._renderEmpty("No entity selected","Please select a rail commute summary sensor in the card configuration");if(this._loading)return this._renderLoading();if(t=this._hasDisruption,this.config.only_show_disrupted&&!t)return this._renderEmpty("No disruption detected","Trains will appear when there is disruption");var t;if(this._entityNotFound)return this._renderEmpty("Entity not found",`Cannot find entity: ${this.config.entity}`);if(!this._trains||0===this._trains.length)return this._renderEmpty();switch(this.config.view||"full"){case"compact":return this._renderCompact();case"next-only":return this._renderNextOnly();case"board":return this._renderBoard();default:return this._renderFull()}}_renderHeader(){const t=!1!==this.config.show_header,e=!1!==this.config.show_route;if(!t)return"";const i=String(this.config.title||"Rail Commute").replace(/<[^>]*>/g,"");return B`
       <div class="card-header">
         <div class="header-content">
           <ha-icon icon="mdi:train"></ha-icon>
           <span class="header-title">${i}</span>
-          ${this._returnEntityId?q`
+          ${this._returnEntityId?B`
             <button
               class="return-toggle ${this._showReturn?"active":""}"
               @click="${this._toggleReturn}"
@@ -1438,13 +1508,13 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
             </button>
           `:""}
         </div>
-        ${e&&this._origin&&this._destination?q`
+        ${e&&this._origin?B`
           <div class="route">
-            ${this._origin} → ${this._destination}
+            ${this._isMultiDestination?B`from ${this._origin}`:B`${this._origin} → ${this._destination}`}
           </div>
         `:""}
       </div>
-    `}_renderDisruptionBanner(){if(!this._hasDisruption)return"";const t={minor:{cls:"disruption-minor",label:"Minor Delays",icon:"mdi:alert"},major:{cls:"disruption-major",label:"Major Delays",icon:"mdi:alert"},severe:{cls:"disruption-severe",label:"Severe Disruption",icon:"mdi:alert-circle"},critical:{cls:"disruption-critical",label:"Critical Disruption",icon:"mdi:alert-octagon"}},{cls:e,label:i,icon:s}=t[this._disruptionSeverity]||t.minor,o=!!this._resolvedStatusEntityId;return q`
+    `}_renderDisruptionBanner(){if(!this._hasDisruption)return"";const t={minor:{cls:"disruption-minor",label:"Minor Delays",icon:"mdi:alert"},major:{cls:"disruption-major",label:"Major Delays",icon:"mdi:alert"},severe:{cls:"disruption-severe",label:"Severe Disruption",icon:"mdi:alert-circle"},critical:{cls:"disruption-critical",label:"Critical Disruption",icon:"mdi:alert-octagon"}},{cls:e,label:i,icon:s}=t[this._disruptionSeverity]||t.minor,o=!!this._resolvedStatusEntityId;return B`
       <div
         class="disruption-banner ${e} ${o?"disruption-clickable":""}"
         @click="${o?()=>this._showDisruptionMoreInfo():null}"
@@ -1453,22 +1523,22 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
         <ha-icon icon="${s}" class="disruption-icon"></ha-icon>
         <div class="disruption-content">
           <span class="disruption-label">${i} on this route</span>
-          ${this._disruptionMessage?q`
+          ${this._disruptionMessage?B`
             <span class="disruption-message">${this._disruptionMessage}</span>
           `:""}
         </div>
-        ${o?q`
+        ${o?B`
           <ha-icon icon="mdi:chevron-right" class="disruption-chevron"></ha-icon>
         `:""}
       </div>
-    `}_showDisruptionMoreInfo(){if(!this._resolvedStatusEntityId)return;const t=new Event("hass-more-info",{bubbles:!0,composed:!0});t.detail={entityId:this._resolvedStatusEntityId},this.dispatchEvent(t)}_renderFooter(){const t=!0===this.config.show_last_updated,e=!0===this.config.show_history_panel;return t||e?q`
+    `}_showDisruptionMoreInfo(){if(!this._resolvedStatusEntityId)return;const t=new Event("hass-more-info",{bubbles:!0,composed:!0});t.detail={entityId:this._resolvedStatusEntityId},this.dispatchEvent(t)}_renderFooter(){const t=!0===this.config.show_last_updated,e=!0===this.config.show_history_panel;return t||e?B`
       <div class="card-footer">
-        ${t?q`
+        ${t?B`
           <span class="last-updated">
             Last updated: ${function(t){if(!t)return"Unknown";try{const e=new Date,i=new Date(t);if(isNaN(i.getTime()))return console.warn("getRelativeTime: invalid timestamp:",t),"Unknown";const s=Math.floor((e-i)/1e3);if(s<0)return"Just now";if(s<60)return"Just now";if(s<3600){const t=Math.floor(s/60);return`${t} minute${1!==t?"s":""} ago`}if(s<86400){const t=Math.floor(s/3600);return`${t} hour${1!==t?"s":""} ago`}const o=Math.floor(s/86400);return`${o} day${1!==o?"s":""} ago`}catch(t){return console.warn("getRelativeTime: error calculating relative time:",t),"Unknown"}}(this._lastUpdated)}
           </span>
-        `:q`<span></span>`}
-        ${e?q`
+        `:B`<span></span>`}
+        ${e?B`
           <button
             class="history-toggle ${this._historyPanelOpen?"active":""}"
             @click="${this._toggleHistoryPanel}"
@@ -1478,11 +1548,11 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
           </button>
         `:""}
       </div>
-    `:""}_renderHistoryPanel(){if(!this.config.show_history_panel||!this._historyPanelOpen)return"";const t=this._histRelAttrs,e=this._histDelAttrs;if(!t&&!e)return q`
+    `:""}_renderHistoryPanel(){if(!this.config.show_history_panel||!this._historyPanelOpen)return"";const t=this._histRelAttrs,e=this._histDelAttrs;if(!t&&!e)return B`
         <div class="history-panel">
           <div class="history-empty">No reliability data available yet — check back after a few updates.</div>
         </div>
-      `;const i=Math.min(this.config.history_days||7,30),s=(t?.daily_breakdown||[]).slice(-i),o=t?.on_time_pct_today??null,r=t?.on_time_pct_7day??null,n=t?.on_time_pct_30day??null,a=e?.avg_delay_7day??null,c=e?.best_day??null,l=e?.worst_day??null;return q`
+      `;const i=Math.min(this.config.history_days||7,30),s=(t?.daily_breakdown||[]).slice(-i),o=t?.on_time_pct_today??null,r=t?.on_time_pct_7day??null,n=t?.on_time_pct_30day??null,a=e?.avg_delay_7day??null,c=e?.best_day??null,l=e?.worst_day??null;return B`
       <div class="history-panel">
         <div class="history-kpis">
           ${this._renderKpiPill("Today",o,"%",!1)}
@@ -1491,21 +1561,21 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
           ${this._renderKpiPill("Avg delay",a," min",!0)}
         </div>
 
-        ${s.length>0?q`
+        ${s.length>0?B`
           <div class="history-days">
             ${s.map(t=>this._renderDaySquare(t))}
           </div>
         `:""}
 
-        ${c||l?q`
+        ${c||l?B`
           <div class="history-bestworst">
-            ${c?q`
+            ${c?B`
               <span class="history-best">
                 <ha-icon icon="mdi:thumb-up-outline"></ha-icon>
                 Best: ${this._formatHistoryDate(c.date)} (${c.on_time_pct}%)
               </span>
-            `:q`<span></span>`}
-            ${l?q`
+            `:B`<span></span>`}
+            ${l?B`
               <span class="history-worst">
                 <ha-icon icon="mdi:thumb-down-outline"></ha-icon>
                 Worst: ${this._formatHistoryDate(l.date)} (${l.on_time_pct}%)
@@ -1514,29 +1584,29 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
           </div>
         `:""}
       </div>
-    `}_renderKpiPill(t,e,i,s){const o=s?"kpi-neutral":null==(r=e)?"kpi-neutral":r>=90?"kpi-good":r>=70?"kpi-moderate":"kpi-poor";var r;return q`
+    `}_renderKpiPill(t,e,i,s){const o=s?"kpi-neutral":null==(r=e)?"kpi-neutral":r>=90?"kpi-good":r>=70?"kpi-moderate":"kpi-poor";var r;return B`
       <div class="kpi-pill ${o}">
         <span class="kpi-value">${null!=e?`${e}${i}`:"—"}</span>
         <span class="kpi-label">${t}</span>
       </div>
-    `}_renderDaySquare(t){const e=t.on_time_pct;let i="day-sq-nodata";null!=e&&(i=e>=90?"day-sq-good":e>=70?"day-sq-moderate":"day-sq-poor");const[s,o,r]=t.date.split("-").map(Number),n=new Date(s,o-1,r).toLocaleDateString("en-GB",{weekday:"short"}),a=null!=e?`${Math.round(e)}%`:"—",c=null!=e?`${n} ${r}: ${e}% on-time${t.avg_delay_minutes?`, avg ${t.avg_delay_minutes} min late`:""}`:`${n} ${r}: No data`;return q`
+    `}_renderDaySquare(t){const e=t.on_time_pct;let i="day-sq-nodata";null!=e&&(i=e>=90?"day-sq-good":e>=70?"day-sq-moderate":"day-sq-poor");const[s,o,r]=t.date.split("-").map(Number),n=new Date(s,o-1,r).toLocaleDateString("en-GB",{weekday:"short"}),a=null!=e?`${Math.round(e)}%`:"—",c=null!=e?`${n} ${r}: ${e}% on-time${t.avg_delay_minutes?`, avg ${t.avg_delay_minutes} min late`:""}`:`${n} ${r}: No data`;return B`
       <div class="day-sq ${i}" title="${c}">
         <span class="day-sq-label">${n}</span>
         <span class="day-sq-pct">${a}</span>
       </div>
-    `}_formatHistoryDate(t){if(!t)return"";const[e,i,s]=t.split("-").map(Number);return new Date(e,i-1,s).toLocaleDateString("en-GB",{weekday:"short",day:"numeric",month:"short"})}_renderFull(){const t=this.config.compact_height?"compact-height":"";return q`
+    `}_formatHistoryDate(t){if(!t)return"";const[e,i,s]=t.split("-").map(Number);return new Date(e,i-1,s).toLocaleDateString("en-GB",{weekday:"short",day:"numeric",month:"short"})}_renderFull(){const t=this.config.compact_height?"compact-height":"",e=this._isMultiDestination&&!1!==this.config.group_by_destination;return B`
       <ha-card class="${t}">
         ${this._renderHeader()}
         ${this._renderDisruptionBanner()}
 
         <div class="card-content">
-          ${this._trains.map(t=>this._renderTrainRow(t))}
+          ${e?this._renderGroupedTrains():this._trains.map(t=>this._renderTrainRow(t))}
         </div>
 
         ${this._renderHistoryPanel()}
         ${this._renderFooter()}
       </ha-card>
-    `}_renderTrainRow(t){const e=pt(t),i=!1!==this.config.status_icons?ut(t):"",s=!1!==this.config.show_platform,o=!1!==this.config.show_operator,r=!1!==this.config.show_delay_reason,n=!0===this.config.show_calling_points,a=!0===this.config.show_journey_time;return q`
+    `}_renderTrainRow(t){const e=pt(t),i=!1!==this.config.status_icons?ut(t):"",s=!1!==this.config.show_platform,o=!1!==this.config.show_operator,r=!1!==this.config.show_delay_reason,n=!0===this.config.show_calling_points,a=!0===this.config.show_journey_time;return B`
       <div
         class="train-row ${e}"
         @click="${()=>this._handleTap(t)}"
@@ -1551,7 +1621,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
             <span class="expected-time">${t.expected_departure&&t.expected_departure!==t.scheduled_departure?lt(t.expected_departure):""}</span>
           </div>
 
-          ${s?q`
+          ${s?B`
             <div class="train-platform">
               Platform ${t.platform||"—"}
             </div>
@@ -1564,57 +1634,77 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
         </div>
 
         <div class="train-details">
-          ${o&&t.operator?q`
+          ${o&&t.operator?B`
             <span class="operator">${t.operator}</span>
           `:""}
 
-          ${r&&t.delay_reason?q`
+          ${r&&t.delay_reason?B`
             <div class="delay-reason">
               → ${t.delay_reason}
             </div>
           `:""}
 
-          ${n&&t.calling_points&&t.calling_points.length>0?q`
+          ${n&&t.calling_points&&t.calling_points.length>0?B`
             <div class="calling-points">
               Calling at: ${function(t,e=3){if(!t||0===t.length)return"";const i=t.slice(0,e),s=t.length-e;let o=i.join(", ");return s>0&&(o+=` +${s} more`),o}(t.calling_points,this.config.max_calling_points)}
             </div>
           `:""}
 
-          ${a&&t.journey_duration?q`
+          ${a&&t.journey_duration?B`
             <div class="journey-time">
               Journey time: ${t.journey_duration} mins${t.journey_time_approx?"*":""}
             </div>
           `:""}
         </div>
       </div>
-    `}_renderCompact(){const t=!0===this.config.show_journey_time;return q`
+    `}_renderGroupedTrains(){const t=gt(this._trains);return B`
+      ${[...t.entries()].map(([t,e])=>{const i=this._servicesByDestination&&this._servicesByDestination[t],s=i?i.status.toLowerCase().replace(/\s+/g,"-"):ft(e);return B`
+          <div class="destination-group">
+            ${this._renderDestinationGroupHeader(t,s)}
+            ${e.map(t=>this._renderTrainRow(t))}
+          </div>
+        `})}
+    `}_renderDestinationGroupHeader(t,e){const i=e.includes("critical")||e.includes("severe")?"status-critical":e.includes("major")?"status-major":e.includes("minor")?"status-minor":"status-normal";return B`
+      <div class="destination-group-header">
+        <span class="dest-arrow">→</span>
+        <span class="dest-name">${t}</span>
+        <span class="dest-status-dot ${i}" title="${e}"></span>
+      </div>
+    `}_renderCompact(){const t=!0===this.config.show_journey_time,e=this._isMultiDestination&&!1!==this.config.group_by_destination,i=e=>B`
+      <div
+        class="train-row-compact ${pt(e)}"
+        @click="${()=>this._handleTap(e)}"
+        @touchstart="${this._handleTouchStart}"
+        @touchend="${this._handleTouchEnd}"
+        @touchmove="${this._handleTouchMove}"
+      >
+        <span class="time">${lt(e.scheduled_departure)}</span>
+        <span class="platform">Plat ${e.platform||"—"}${t&&e.journey_duration?B` · ${e.journey_duration}m${e.journey_time_approx?"*":""}`:""}</span>
+        <span class="status">
+          ${!1!==this.config.status_icons?B`<span class="status-icon">${ut(e)}</span>`:""}
+          ${e.delay_minutes>0?B`<span class="delay-text">+${e.delay_minutes}m</span>`:""}
+        </span>
+      </div>
+    `,s=e?(()=>{const t=gt(this._trains);return B`
+            ${[...t.entries()].map(([t,e])=>{const s=this._servicesByDestination&&this._servicesByDestination[t],o=s?s.status.toLowerCase().replace(/\s+/g,"-"):ft(e);return B`
+                <div class="destination-group">
+                  ${this._renderDestinationGroupHeader(t,o)}
+                  ${e.map(i)}
+                </div>
+              `})}
+          `})():this._trains.map(i);return B`
       <ha-card class="${this.config.compact_height?"compact-height":""}">
         ${this._renderHeader()}
         ${this._renderDisruptionBanner()}
 
         <div class="card-content compact">
-          ${this._trains.map(e=>q`
-              <div
-                class="train-row-compact ${pt(e)}"
-                @click="${()=>this._handleTap(e)}"
-                @touchstart="${this._handleTouchStart}"
-                @touchend="${this._handleTouchEnd}"
-                @touchmove="${this._handleTouchMove}"
-              >
-                <span class="time">${lt(e.scheduled_departure)}</span>
-                <span class="platform">Plat ${e.platform||"—"}${t&&e.journey_duration?q` · ${e.journey_duration}m${e.journey_time_approx?"*":""}`:""}</span>
-                <span class="status">
-                  ${!1!==this.config.status_icons?q`<span class="status-icon">${ut(e)}</span>`:""}
-                  ${e.delay_minutes>0?q`<span class="delay-text">+${e.delay_minutes}m</span>`:""}
-                </span>
-              </div>
-            `)}
+          ${s}
         </div>
 
         ${this._renderHistoryPanel()}
         ${this._renderFooter()}
       </ha-card>
-    `}_renderNextOnly(){const t=this._trains[0];if(!t)return this._renderEmpty();const e=pt(t),i=!1!==this.config.status_icons?ut(t):"",s=!0===this.config.show_journey_time;return q`
+    `}_renderNextOnly(){const t=this._trains[0];if(!t)return this._renderEmpty();const e=pt(t),i=!1!==this.config.status_icons?ut(t):"",s=!0===this.config.show_journey_time;return B`
       <ha-card class="${this.config.compact_height?"compact-height":""}">
         ${this._renderHeader()}
         ${this._renderDisruptionBanner()}
@@ -1624,7 +1714,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
             ${lt(t.scheduled_departure)}
           </div>
 
-          ${t.expected_departure&&t.expected_departure!==t.scheduled_departure?q`
+          ${t.expected_departure&&t.expected_departure!==t.scheduled_departure?B`
             <div class="next-train-expected">
               Expected: ${lt(t.expected_departure)}
             </div>
@@ -1638,20 +1728,20 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
             ${i} ${_t(t)}
           </div>
 
-          ${t.operator?q`
+          ${t.operator?B`
             <div class="next-train-operator">
               ${t.operator}
             </div>
           `:""}
 
-          ${t.calling_points&&t.calling_points.length>0?q`
+          ${t.calling_points&&t.calling_points.length>0?B`
             <div class="next-train-calling">
               <strong>Calling at:</strong><br>
               ${t.calling_points.join(", ")}
             </div>
           `:""}
 
-          ${s&&t.journey_duration?q`
+          ${s&&t.journey_duration?B`
             <div class="next-train-journey-time">
               Journey time: ${t.journey_duration} mins${t.journey_time_approx?"*":""}
             </div>
@@ -1662,7 +1752,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
         ${this._renderHistoryPanel()}
         ${this._renderFooter()}
       </ha-card>
-    `}_renderBoard(){const t=!0===this.config.show_journey_time;return q`
+    `}_renderBoard(){const t=!0===this.config.show_journey_time;return B`
       <ha-card class="departure-board">
         <div class="board-header">
           DEPARTURES  ${this._origin||""}
@@ -1678,7 +1768,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
               <span class="col-status">Status</span>
             </div>
 
-            ${this._trains.map(e=>q`
+            ${this._trains.map(e=>B`
                 <div
                   class="board-row ${pt(e)}"
                   @click="${()=>this._handleTap(e)}"
@@ -1690,7 +1780,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
                     ${lt(e.scheduled_departure)}
                   </span>
                   <span class="col-dest">
-                    ${function(t){if(!t)return"";if(t.length<=12)return t;const e={London:"Ldn",Street:"St",Bridge:"Bdg",Junction:"Jn",Central:"Cen",International:"Intl",Station:"Stn",Road:"Rd",Cross:"X",Park:"Pk"};let i=t;for(const[t,s]of Object.entries(e))i=i.replace(new RegExp(t,"g"),s);return i.length>12&&(i=i.substring(0,11)+"…"),i}(this._destination||"")}
+                    ${this._isMultiDestination?mt(e.destination||""):mt(this._destination||"")}
                   </span>
                   <span class="col-plat">
                     ${e.platform||"—"}
@@ -1706,7 +1796,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
         ${this._renderHistoryPanel()}
         ${this._renderFooter()}
       </ha-card>
-    `}_renderEmpty(t="No trains found",e="Check your time window or station codes"){return q`
+    `}_renderEmpty(t="No trains found",e="Check your time window or station codes"){return B`
       <ha-card>
         ${this._renderHeader()}
 
@@ -1716,7 +1806,7 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
           <div class="empty-submessage">${e}</div>
         </div>
       </ha-card>
-    `}_renderLoading(){return q`
+    `}_renderLoading(){return B`
       <ha-card>
         ${this._renderHeader()}
 
@@ -1725,4 +1815,4 @@ const w=globalThis,x=t=>t,C=w.trustedTypes,E=C?C.createPolicy("lit-html",{create
           <div class="loading-message">Loading train information...</div>
         </div>
       </ha-card>
-    `}_handleTap(t){switch(this.config.tap_action?.action||"more-info"){case"more-info":this._showMoreInfo(t);break;case"url":this._openUrl(t);break;case"navigate":this._navigate(t)}}_showMoreInfo(t){const e=new Event("hass-more-info",{bubbles:!0,composed:!0}),i=t?.train_id||this.config.entity;e.detail={entityId:i},this.dispatchEvent(e)}_openUrl(t){const e=this.config.tap_action?.url_path;if(e)window.open(e,"_blank");else{const t=`https://www.nationalrail.co.uk/journey-planner/?from=${this._origin||""}&to=${this._destination||""}`;window.open(t,"_blank")}}_navigate(t){const e=this.config.tap_action?.navigation_path;if(e){window.history.pushState(null,"",e);const t=new Event("location-changed",{bubbles:!0,composed:!0});this.dispatchEvent(t)}}_handleTouchStart(t){const e=t.currentTarget;e._pressTimer=setTimeout(()=>{e._pressTimer=null,this._handleHold()},500)}_handleTouchEnd(t){const e=t.currentTarget;e._pressTimer&&(clearTimeout(e._pressTimer),e._pressTimer=null)}_handleTouchMove(t){const e=t.currentTarget;e._pressTimer&&(clearTimeout(e._pressTimer),e._pressTimer=null)}_handleHold(){"refresh"===(this.config.hold_action?.action||"refresh")&&this._refreshData()}_refreshData(){this._hass&&(this._hass.callService("homeassistant","update_entity",{entity_id:this.config.entity}),this._showRefreshFeedback())}_showRefreshFeedback(){this._toastTimer&&(clearTimeout(this._toastTimer),this._toastTimer=null),this._toastElement&&(this._toastElement.remove(),this._toastElement=null);const t=document.createElement("div");t.className="refresh-toast",t.textContent="Refreshing...",this.shadowRoot.appendChild(t),this._toastElement=t,this._toastTimer=setTimeout(()=>{this._toastTimer=null,this._toastElement=null,t.isConnected&&t.remove()},2e3)}disconnectedCallback(){super.disconnectedCallback(),this._toastTimer&&(clearTimeout(this._toastTimer),this._toastTimer=null),this._toastElement&&(this._toastElement.remove(),this._toastElement=null)}static getConfigElement(){return document.createElement("my-rail-commute-card-editor")}static getStubConfig(){return{entity:"",view:"full",show_platform:!0,show_operator:!0,show_calling_points:!1}}}customElements.define("my-rail-commute-card",mt),window.customCards=window.customCards||[],window.customCards.push({type:"my-rail-commute-card",name:"My Rail Commute Card",description:"Display My Rail Commute departure information in a beautiful station-board interface",preview:!0,documentationURL:"https://github.com/adamf83/lovelace-my-rail-commute-card"});export{mt as default};
+    `}_handleTap(t){switch(this.config.tap_action?.action||"more-info"){case"more-info":this._showMoreInfo(t);break;case"url":this._openUrl(t);break;case"navigate":this._navigate(t)}}_showMoreInfo(t){const e=new Event("hass-more-info",{bubbles:!0,composed:!0}),i=t?.train_id||this.config.entity;e.detail={entityId:i},this.dispatchEvent(e)}_openUrl(t){const e=this.config.tap_action?.url_path;if(e)window.open(e,"_blank");else{const t=`https://www.nationalrail.co.uk/journey-planner/?from=${this._origin||""}&to=${this._destination||""}`;window.open(t,"_blank")}}_navigate(t){const e=this.config.tap_action?.navigation_path;if(e){window.history.pushState(null,"",e);const t=new Event("location-changed",{bubbles:!0,composed:!0});this.dispatchEvent(t)}}_handleTouchStart(t){const e=t.currentTarget;e._pressTimer=setTimeout(()=>{e._pressTimer=null,this._handleHold()},500)}_handleTouchEnd(t){const e=t.currentTarget;e._pressTimer&&(clearTimeout(e._pressTimer),e._pressTimer=null)}_handleTouchMove(t){const e=t.currentTarget;e._pressTimer&&(clearTimeout(e._pressTimer),e._pressTimer=null)}_handleHold(){"refresh"===(this.config.hold_action?.action||"refresh")&&this._refreshData()}_refreshData(){this._hass&&(this._hass.callService("homeassistant","update_entity",{entity_id:this.config.entity}),this._showRefreshFeedback())}_showRefreshFeedback(){this._toastTimer&&(clearTimeout(this._toastTimer),this._toastTimer=null),this._toastElement&&(this._toastElement.remove(),this._toastElement=null);const t=document.createElement("div");t.className="refresh-toast",t.textContent="Refreshing...",this.shadowRoot.appendChild(t),this._toastElement=t,this._toastTimer=setTimeout(()=>{this._toastTimer=null,this._toastElement=null,t.isConnected&&t.remove()},2e3)}disconnectedCallback(){super.disconnectedCallback(),this._toastTimer&&(clearTimeout(this._toastTimer),this._toastTimer=null),this._toastElement&&(this._toastElement.remove(),this._toastElement=null)}static getConfigElement(){return document.createElement("my-rail-commute-card-editor")}static getStubConfig(){return{entity:"",view:"full",show_platform:!0,show_operator:!0,show_calling_points:!1}}}customElements.define("my-rail-commute-card",yt),window.customCards=window.customCards||[],window.customCards.push({type:"my-rail-commute-card",name:"My Rail Commute Card",description:"Display My Rail Commute departure information in a beautiful station-board interface",preview:!0,documentationURL:"https://github.com/adamf83/lovelace-my-rail-commute-card"});export{yt as default};

--- a/src/editor.js
+++ b/src/editor.js
@@ -292,6 +292,15 @@ class MyRailCommuteCardEditor extends LitElement {
             ></ha-switch>
           </ha-formfield>
 
+          ${this._isMultiDestinationSensor() ? html`
+            <ha-formfield label="Group Trains by Destination">
+              <ha-switch
+                .checked=${this._config.group_by_destination !== false}
+                @change=${this._toggleChanged('group_by_destination')}
+              ></ha-switch>
+            </ha-formfield>
+          ` : ''}
+
         </div>
 
         <!-- Filtering Options -->
@@ -573,6 +582,12 @@ class MyRailCommuteCardEditor extends LitElement {
     if (!this._config || !this._hass) return;
     this._config = { ...this._config, history_days: parseInt(ev.target.value, 10) };
     this._fireConfigChanged();
+  }
+
+  _isMultiDestinationSensor() {
+    if (!this._hass || !this._config?.entity) return false;
+    const state = this._hass.states[this._config.entity];
+    return state?.attributes?.multi_destination === true;
   }
 
   _fireConfigChanged() {

--- a/src/my-rail-commute-card.js
+++ b/src/my-rail-commute-card.js
@@ -14,7 +14,9 @@ import {
   getTrainIcon,
   shouldShowTrains,
   calculateJourneyDuration,
-  getReliabilityClass
+  getReliabilityClass,
+  groupTrainsByDestination,
+  getGroupStatus
 } from './utils.js';
 import './editor.js'; // Import editor to bundle it
 
@@ -44,6 +46,8 @@ class MyRailCommuteCard extends LitElement {
       _historyPanelOpen: { type: Boolean },
       _histRelAttrs: { type: Object },
       _histDelAttrs: { type: Object },
+      _isMultiDestination: { type: Boolean },
+      _servicesByDestination: { type: Object },
     };
   }
 
@@ -71,6 +75,8 @@ class MyRailCommuteCard extends LitElement {
     this._historyPanelOpen = false;
     this._histRelAttrs = null;
     this._histDelAttrs = null;
+    this._isMultiDestination = false;
+    this._servicesByDestination = null;
   }
 
   setConfig(config) {
@@ -107,6 +113,7 @@ class MyRailCommuteCard extends LitElement {
       status_icons: true,
       show_history_panel: false,
       history_days: 7,
+      group_by_destination: true,
       ...config
     };
 
@@ -243,9 +250,13 @@ class MyRailCommuteCard extends LitElement {
       this._trains = this._getTrainsFromIndividualSensors(hass, activeEntityId);
     }
 
+    // Detect multi-destination mode from sensor attributes
+    this._isMultiDestination = activeEntity.attributes.multi_destination === true;
+    this._servicesByDestination = activeEntity.attributes.services_by_destination || null;
+
     // Set route display — swap origin/destination when showing return journey
     this._origin = this._showReturn ? outboundDest : outboundOrigin;
-    this._destination = this._showReturn ? outboundOrigin : outboundDest;
+    this._destination = this._isMultiDestination ? null : (this._showReturn ? outboundOrigin : outboundDest);
     this._lastUpdated = activeEntity.attributes.last_updated ||
                         activeEntity.last_updated ||
                         activeEntity.last_changed || '';
@@ -346,7 +357,8 @@ class MyRailCommuteCard extends LitElement {
   }
 
   _findReturnEntity(hass, origin, destination) {
-    if (!origin || !destination) return null;
+    // No return journey concept for all-departures mode
+    if (!origin || !destination || this._isMultiDestination) return null;
     const originLower = origin.toLowerCase().trim();
     const destLower = destination.toLowerCase().trim();
 
@@ -591,9 +603,11 @@ class MyRailCommuteCard extends LitElement {
             </button>
           ` : ''}
         </div>
-        ${showRoute && this._origin && this._destination ? html`
+        ${showRoute && this._origin ? html`
           <div class="route">
-            ${this._origin} → ${this._destination}
+            ${this._isMultiDestination
+              ? html`from ${this._origin}`
+              : html`${this._origin} → ${this._destination}`}
           </div>
         ` : ''}
       </div>
@@ -774,6 +788,7 @@ class MyRailCommuteCard extends LitElement {
 
   _renderFull() {
     const compactClass = this.config.compact_height ? 'compact-height' : '';
+    const useGroups = this._isMultiDestination && this.config.group_by_destination !== false;
 
     return html`
       <ha-card class="${compactClass}">
@@ -781,7 +796,9 @@ class MyRailCommuteCard extends LitElement {
         ${this._renderDisruptionBanner()}
 
         <div class="card-content">
-          ${this._trains.map(train => this._renderTrainRow(train))}
+          ${useGroups
+            ? this._renderGroupedTrains()
+            : this._trains.map(train => this._renderTrainRow(train))}
         </div>
 
         ${this._renderHistoryPanel()}
@@ -853,8 +870,78 @@ class MyRailCommuteCard extends LitElement {
     `;
   }
 
+  _renderGroupedTrains() {
+    const groups = groupTrainsByDestination(this._trains);
+    return html`
+      ${[...groups.entries()].map(([dest, trains]) => {
+        const sensorGroup = this._servicesByDestination && this._servicesByDestination[dest];
+        const status = sensorGroup ? sensorGroup.status.toLowerCase().replace(/\s+/g, '-') : getGroupStatus(trains);
+        return html`
+          <div class="destination-group">
+            ${this._renderDestinationGroupHeader(dest, status)}
+            ${trains.map(train => this._renderTrainRow(train))}
+          </div>
+        `;
+      })}
+    `;
+  }
+
+  _renderDestinationGroupHeader(destination, status) {
+    const dotClass = status.includes('critical') || status.includes('severe')
+      ? 'status-critical'
+      : status.includes('major')
+        ? 'status-major'
+        : status.includes('minor')
+          ? 'status-minor'
+          : 'status-normal';
+
+    return html`
+      <div class="destination-group-header">
+        <span class="dest-arrow">→</span>
+        <span class="dest-name">${destination}</span>
+        <span class="dest-status-dot ${dotClass}" title="${status}"></span>
+      </div>
+    `;
+  }
+
   _renderCompact() {
     const showJourneyTime = this.config.show_journey_time === true;
+    const useGroups = this._isMultiDestination && this.config.group_by_destination !== false;
+
+    const renderCompactRow = (train) => html`
+      <div
+        class="train-row-compact ${getStatusClass(train)}"
+        @click="${() => this._handleTap(train)}"
+        @touchstart="${this._handleTouchStart}"
+        @touchend="${this._handleTouchEnd}"
+        @touchmove="${this._handleTouchMove}"
+      >
+        <span class="time">${formatTime(train.scheduled_departure)}</span>
+        <span class="platform">Plat ${train.platform || '—'}${showJourneyTime && train.journey_duration ? html` · ${train.journey_duration}m${train.journey_time_approx ? '*' : ''}` : ''}</span>
+        <span class="status">
+          ${this.config.status_icons !== false ? html`<span class="status-icon">${getStatusIcon(train)}</span>` : ''}
+          ${train.delay_minutes > 0 ? html`<span class="delay-text">+${train.delay_minutes}m</span>` : ''}
+        </span>
+      </div>
+    `;
+
+    const content = useGroups
+      ? (() => {
+          const groups = groupTrainsByDestination(this._trains);
+          return html`
+            ${[...groups.entries()].map(([dest, trains]) => {
+              const sensorGroup = this._servicesByDestination && this._servicesByDestination[dest];
+              const status = sensorGroup ? sensorGroup.status.toLowerCase().replace(/\s+/g, '-') : getGroupStatus(trains);
+              return html`
+                <div class="destination-group">
+                  ${this._renderDestinationGroupHeader(dest, status)}
+                  ${trains.map(renderCompactRow)}
+                </div>
+              `;
+            })}
+          `;
+        })()
+      : this._trains.map(renderCompactRow);
 
     return html`
       <ha-card class="${this.config.compact_height ? 'compact-height' : ''}">
@@ -862,24 +949,7 @@ class MyRailCommuteCard extends LitElement {
         ${this._renderDisruptionBanner()}
 
         <div class="card-content compact">
-          ${this._trains.map(train => {
-            return html`
-              <div
-                class="train-row-compact ${getStatusClass(train)}"
-                @click="${() => this._handleTap(train)}"
-                @touchstart="${this._handleTouchStart}"
-                @touchend="${this._handleTouchEnd}"
-                @touchmove="${this._handleTouchMove}"
-              >
-                <span class="time">${formatTime(train.scheduled_departure)}</span>
-                <span class="platform">Plat ${train.platform || '—'}${showJourneyTime && train.journey_duration ? html` · ${train.journey_duration}m${train.journey_time_approx ? '*' : ''}` : ''}</span>
-                <span class="status">
-                  ${this.config.status_icons !== false ? html`<span class="status-icon">${getStatusIcon(train)}</span>` : ''}
-                  ${train.delay_minutes > 0 ? html`<span class="delay-text">+${train.delay_minutes}m</span>` : ''}
-                </span>
-              </div>
-            `;
-          })}
+          ${content}
         </div>
 
         ${this._renderHistoryPanel()}
@@ -982,7 +1052,9 @@ class MyRailCommuteCard extends LitElement {
                     ${formatTime(train.scheduled_departure)}
                   </span>
                   <span class="col-dest">
-                    ${abbreviateStation(this._destination || '')}
+                    ${this._isMultiDestination
+                      ? abbreviateStation(train.destination || '')
+                      : abbreviateStation(this._destination || '')}
                   </span>
                   <span class="col-plat">
                     ${train.platform || '—'}

--- a/src/styles.js
+++ b/src/styles.js
@@ -195,6 +195,67 @@ export const styles = css`
     padding: 0;
   }
 
+  /* ==================== DESTINATION GROUPS (multi-destination mode) ==================== */
+
+  .destination-group {
+    border-top: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
+  }
+
+  .destination-group:first-child {
+    border-top: none;
+  }
+
+  .destination-group-header {
+    display: flex;
+    align-items: center;
+    padding: 8px var(--card-padding) 4px;
+    gap: 6px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--secondary-text-color, #757575);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: var(--secondary-background-color, rgba(0, 0, 0, 0.03));
+    border-bottom: 1px solid var(--divider-color, rgba(0, 0, 0, 0.08));
+  }
+
+  .destination-group-header .dest-arrow {
+    opacity: 0.5;
+    font-size: 0.9rem;
+  }
+
+  .destination-group-header .dest-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .destination-group-header .dest-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--status-on-time, #4caf50);
+  }
+
+  .destination-group-header .dest-status-dot.status-critical,
+  .destination-group-header .dest-status-dot.status-severe {
+    background: var(--status-cancelled, #d32f2f);
+  }
+
+  .destination-group-header .dest-status-dot.status-major {
+    background: var(--status-major-delay, #f44336);
+  }
+
+  .destination-group-header .dest-status-dot.status-minor {
+    background: var(--status-minor-delay, #ff9800);
+  }
+
+  .destination-group-header .dest-status-dot.status-normal {
+    background: var(--status-on-time, #4caf50);
+  }
+
   /* ==================== FULL VIEW ==================== */
 
   .train-row {

--- a/src/utils.js
+++ b/src/utils.js
@@ -384,6 +384,38 @@ export function truncateText(text, maxLength) {
 }
 
 /**
+ * Group trains by their destination field, preserving first-seen order (chronological).
+ * Returns a Map so iteration order equals the order the first train per destination appeared.
+ * @param {Array} trains - Array of train objects, each with a `destination` field
+ * @returns {Map<string, Array>} Map of destination name → trains for that destination
+ */
+export function groupTrainsByDestination(trains) {
+  const groups = new Map();
+  for (const train of trains) {
+    const dest = (train.destination && String(train.destination).trim()) || 'Unknown';
+    if (!groups.has(dest)) groups.set(dest, []);
+    groups.get(dest).push(train);
+  }
+  return groups;
+}
+
+/**
+ * Derive a simple status label for a group of trains (mirrors coordinator logic client-side).
+ * Used as a fallback when services_by_destination is not available from the sensor.
+ * @param {Array} trains - Trains for one destination
+ * @returns {string} 'critical' | 'severe' | 'major' | 'minor' | 'normal'
+ */
+export function getGroupStatus(trains) {
+  if (!trains || trains.length === 0) return 'normal';
+  if (trains.some(t => t.is_cancelled)) return 'critical';
+  const maxDelay = Math.max(...trains.map(t => t.delay_minutes || 0));
+  if (maxDelay >= 15) return 'severe';
+  if (maxDelay >= 10) return 'major';
+  if (maxDelay > 0) return 'minor';
+  return 'normal';
+}
+
+/**
  * Get CSS class for a reliability percentage value
  * @param {number|null} pct - On-time percentage (0-100) or null
  * @returns {string} CSS class name


### PR DESCRIPTION
When the backend integration is configured with all_departures=True, the sensor exposes multi_destination=true and services_by_destination attributes. The card detects these and:

- Renders trains grouped by destination (→ Bristol, → Cardiff, etc.) with a header row for each group in full and compact views
- Shows a colour-coded status dot per destination group (green=Normal, orange=Minor, red=Major/Critical) derived from server-side status or computed client-side as a fallback
- Uses each train's own destination field in the board view's Dest column instead of the fixed single-route destination
- Shows "from [Origin]" instead of "Origin → Destination" in the route header line when in multi-destination mode
- Suppresses return-journey toggle for all-departures sensors
- New group_by_destination card config option (default true) lets users switch to a flat list if preferred
- Editor shows group_by_destination toggle when the selected entity is a multi-destination sensor

https://claude.ai/code/session_015j49iQAwKvb3vDxab5NQuU