### PR TITLE
ci: build and attach release asset for pre-releases too

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [released]
+    types: [released, prereleased]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- The release workflow only triggered on GitHub's `released` event, which is not fired for pre-release publishes (GitHub fires `prereleased` instead).
- This left alpha/pre-release tags (e.g. `V1.0.7a0`) without a built `my-rail-commute-card.js` asset attached, so HACS installs tracking a pre-release had nothing to download — surfacing in Home Assistant as a `Custom element not found: my-rail-commute-card` error.
- Adds `prereleased` alongside `released` to the workflow trigger so pre-release tags get the build-and-upload step too.

## Test plan
- [x] Confirmed via the GitHub API that the existing `V1.0.7a0` release is marked `prerelease: true` with `assets: []`, matching the reported symptom.
- [ ] After merge, cut a new pre-release tag (or re-publish an existing one) and confirm the `Build and Release` workflow runs and attaches `dist/my-rail-commute-card.js` as a release asset.

Note: this fix only applies to releases published after merge. The existing `V1.0.7a0` release will need to be re-published (or have its pre-release flag toggled) to pick up an asset, since its `prereleased` event already fired before this workflow understood it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SznnFbETAxBiAHGY2JKsyL)_